### PR TITLE
Fix the error which was raised for monthly, weekly and annual frequencies

### DIFF
--- a/python-lib/dku_timeseries/timeseries_helpers.py
+++ b/python-lib/dku_timeseries/timeseries_helpers.py
@@ -127,12 +127,12 @@ def format_group_id(group_id, identifiers_number):
     return group_id
 
 
-def convert_to_rolling_compatible_time_unit(window_width, window_unit):
-    if window_unit == 'weeks' or window_unit.startswith("W"):
-        return 7 * window_width, 'days'
-    elif window_unit == 'months' or window_unit == "M":
-        return 30 * window_width, 'days'
-    elif window_unit == 'years' or window_unit.startswith("A"):
-        return 365 * window_width, 'days'
+def convert_to_rolling_compatible_time_unit(time_step, time_unit):
+    if time_unit == 'weeks' or time_unit.startswith("W"):
+        return 7 * time_step, 'days'
+    elif time_unit == 'months' or time_unit == "M":
+        return 30 * time_step, 'days'
+    elif time_unit == 'years' or time_unit.startswith("A"):
+        return 365 * time_step, 'days'
     else:
-        return window_width, window_unit
+        return time_step, time_unit

--- a/python-lib/dku_timeseries/timeseries_helpers.py
+++ b/python-lib/dku_timeseries/timeseries_helpers.py
@@ -132,7 +132,7 @@ def convert_to_rolling_compatible_time_unit(window_width, window_unit):
         return 7 * window_width, 'days'
     elif window_unit == 'months' or window_unit == "M":
         return 30 * window_width, 'days'
-    elif window_unit == 'years' or window_unit == "Y":
+    elif window_unit == 'years' or window_unit.startswith("A"):
         return 365 * window_width, 'days'
     else:
         return window_width, window_unit

--- a/python-lib/dku_timeseries/timeseries_helpers.py
+++ b/python-lib/dku_timeseries/timeseries_helpers.py
@@ -97,8 +97,8 @@ def get_smaller_unit(window_unit):
 
 
 def convert_time_freq_to_row_freq(frequency, window_description):
-    data_frequency = to_offset(frequency)
-    time_step, time_unit = convert_to_rolling_compatible_time_unit(data_frequency.n, data_frequency.name)
+    data_frequency_offset = to_offset(frequency)
+    time_step, time_unit = convert_to_rolling_compatible_time_unit(data_frequency_offset.n, data_frequency_offset.name)
     time_description = str(time_step) + FREQUENCY_STRINGS.get(time_unit, time_unit)
     data_frequency = pd.to_timedelta(to_offset(time_description))
     demanded_frequency = pd.to_timedelta(to_offset(window_description))

--- a/python-lib/dku_timeseries/timeseries_helpers.py
+++ b/python-lib/dku_timeseries/timeseries_helpers.py
@@ -97,7 +97,10 @@ def get_smaller_unit(window_unit):
 
 
 def convert_time_freq_to_row_freq(frequency, window_description):
-    data_frequency = pd.to_timedelta(to_offset(frequency))
+    data_frequency = to_offset(frequency)
+    time_step, time_unit = convert_to_rolling_compatible_time_unit(data_frequency.n, data_frequency.name)
+    time_description = str(time_step) + FREQUENCY_STRINGS.get(time_unit, time_unit)
+    data_frequency = pd.to_timedelta(to_offset(time_description))
     demanded_frequency = pd.to_timedelta(to_offset(window_description))
     n = demanded_frequency / data_frequency
     if n < 1:
@@ -122,3 +125,14 @@ def format_group_id(group_id, identifiers_number):
     else:
         group_id = list(group_id)
     return group_id
+
+
+def convert_to_rolling_compatible_time_unit(window_width, window_unit):
+    if window_unit == 'weeks' or window_unit.startswith("W"):
+        return 7 * window_width, 'days'
+    elif window_unit == 'months' or window_unit == "M":
+        return 30 * window_width, 'days'
+    elif window_unit == 'years' or window_unit == "Y":
+        return 365 * window_width, 'days'
+    else:
+        return window_width, window_unit

--- a/python-lib/dku_timeseries/timeseries_helpers.py
+++ b/python-lib/dku_timeseries/timeseries_helpers.py
@@ -130,7 +130,7 @@ def format_group_id(group_id, identifiers_number):
 def convert_to_rolling_compatible_time_unit(time_step, time_unit):
     if time_unit == 'weeks' or time_unit.startswith("W"):
         return 7 * time_step, 'days'
-    elif time_unit == 'months' or time_unit == "M":
+    elif time_unit == 'months' or time_unit.startswith("M"):
         return 30 * time_step, 'days'
     elif time_unit == 'years' or time_unit.startswith("A"):
         return 365 * time_step, 'days'

--- a/python-lib/dku_timeseries/timeseries_helpers.py
+++ b/python-lib/dku_timeseries/timeseries_helpers.py
@@ -99,8 +99,8 @@ def get_smaller_unit(window_unit):
 def convert_time_freq_to_row_freq(frequency, window_description):
     data_frequency_offset = to_offset(frequency)
     time_step, time_unit = convert_to_rolling_compatible_time_unit(data_frequency_offset.n, data_frequency_offset.name)
-    time_description = str(time_step) + FREQUENCY_STRINGS.get(time_unit, time_unit)
-    data_frequency = pd.to_timedelta(to_offset(time_description))
+    formatted_frequency = str(time_step) + FREQUENCY_STRINGS.get(time_unit, time_unit)
+    data_frequency = pd.to_timedelta(to_offset(formatted_frequency))
     demanded_frequency = pd.to_timedelta(to_offset(window_description))
     n = demanded_frequency / data_frequency
     if n < 1:

--- a/python-lib/dku_timeseries/windowing.py
+++ b/python-lib/dku_timeseries/windowing.py
@@ -6,7 +6,8 @@ import numpy as np
 import pandas as pd
 
 from dku_timeseries.dataframe_helpers import has_duplicates, nothing_to_do, generic_check_compute_arguments
-from dku_timeseries.timeseries_helpers import convert_time_freq_to_row_freq, get_smaller_unit, infer_frequency, FREQUENCY_STRINGS, format_group_id
+from dku_timeseries.timeseries_helpers import convert_time_freq_to_row_freq, get_smaller_unit, infer_frequency, FREQUENCY_STRINGS, format_group_id, \
+    convert_to_rolling_compatible_time_unit
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +56,7 @@ class WindowAggregatorParams:  # TODO better naming ?
                  aggregation_types=AGGREGATION_TYPES):
 
         self.causal_window = causal_window
-        self.window_width, self.window_unit = self._convert_to_rolling_compatible_time_unit(window_width, window_unit)
+        self.window_width, self.window_unit = convert_to_rolling_compatible_time_unit(window_width, window_unit)
         self.window_description = str(self.window_width) + FREQUENCY_STRINGS.get(self.window_unit, '')
         self.min_period = min_period
         self.closed_option = closed_option
@@ -77,16 +78,6 @@ class WindowAggregatorParams:  # TODO better naming ?
             raise ValueError('"{0}" is not a valid closed option. Possible values are: {1}'.format(self.closed_option, CLOSED_OPTIONS))
         if self.window_unit == 'rows':
             raise NotImplementedError
-
-    def _convert_to_rolling_compatible_time_unit(self, window_width, window_unit):
-        if window_unit == 'weeks':
-            return 7 * window_width, 'days'
-        elif window_unit == 'months':
-            return 30 * window_width, 'days'
-        elif window_unit == 'years':
-            return 365 * window_width, 'days'
-        else:
-            return window_width, window_unit
 
 
 class WindowAggregator:

--- a/tests/python/unit/dku_timeseries/extrema_extraction/test_extrema_frequencies.py
+++ b/tests/python/unit/dku_timeseries/extrema_extraction/test_extrema_frequencies.py
@@ -1,0 +1,66 @@
+import pandas as pd
+import pytest
+
+from dku_timeseries import WindowAggregator, ExtremaExtractorParams, WindowAggregatorParams, ExtremaExtractor
+
+
+@pytest.fixture
+def monthly_df():
+    co2 = [4, 9, 4, 2, 5, 1]
+    time_index = pd.date_range("1-1-2015", periods=6, freq="M")
+    df = pd.DataFrame.from_dict(
+        {"value1": co2, "value2": co2, "Date": time_index})
+    return df
+
+
+@pytest.fixture
+def recipe_config():
+    config = {u'window_type': u'none', u'groupby_columns': [u'country'], u'closed_option': u'left', u'window_unit': u'months', u'window_width': 2,
+              u'causal_window': False, u'datetime_column': u'Date', u'advanced_activated': True, u'extrema_column': u'value1', u'extrema_type': u'max',
+              u'aggregation_types': [u'average'], u'gaussian_std': 1}
+    return config
+
+
+@pytest.fixture
+def params(recipe_config):
+    def _p(param_name, default=None):
+        return recipe_config.get(param_name, default)
+
+    causal_window = _p('causal_window')
+    window_unit = _p('window_unit')
+    window_width = int(_p('window_width'))
+    if _p('window_type') == 'none':
+        window_type = None
+    else:
+        window_type = _p('window_type')
+
+    if window_type == 'gaussian':
+        gaussian_std = _p('gaussian_std')
+    else:
+        gaussian_std = None
+    closed_option = _p('closed_option')
+    extrema_type = _p('extrema_type')
+    aggregation_types = _p('aggregation_types') + ['retrieve']
+
+    window_params = WindowAggregatorParams(window_unit=window_unit,
+                                           window_width=window_width,
+                                           window_type=window_type,
+                                           gaussian_std=gaussian_std,
+                                           closed_option=closed_option,
+                                           causal_window=causal_window,
+                                           aggregation_types=aggregation_types)
+
+    window_aggregator = WindowAggregator(window_params)
+    params = ExtremaExtractorParams(window_aggregator=window_aggregator, extrema_type=extrema_type)
+    params.check()
+    return params
+
+
+class TestExtremaFrequencies:
+    def test_monthly_frequency(self, monthly_df, params, recipe_config):
+        datetime_column = recipe_config.get('datetime_column')
+        extrema_column = "value1"
+        extrema_extractor = ExtremaExtractor(params)
+        output_df = extrema_extractor.compute(monthly_df, datetime_column, extrema_column)
+        assert output_df.loc[0, "value1_avg"] == 6.5
+        assert output_df.shape == (1, 5)

--- a/tests/python/unit/dku_timeseries/windowing/test_windowing_frequencies.py
+++ b/tests/python/unit/dku_timeseries/windowing/test_windowing_frequencies.py
@@ -1,0 +1,60 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from dku_timeseries import WindowAggregatorParams, WindowAggregator
+
+
+@pytest.fixture
+def monthly_df():
+    co2 = [4,9,4,2,5,1]
+    time_index = pd.date_range("1-1-2015", periods=6, freq="M")
+    df = pd.DataFrame.from_dict(
+        {"value1": co2, "value2": co2, "Date": time_index})
+    return df
+
+@pytest.fixture
+def recipe_config():
+    config = {u'window_type': u'gaussian', u'groupby_columns': [u'country'], u'closed_option': u'left', u'window_unit': u'months', u'window_width': 1,
+              u'causal_window': True, u'datetime_column': u'Date', u'advanced_activated': False, u'aggregation_types': [u'average',"sum"],
+              u'gaussian_std': 1}
+    return config
+
+@pytest.fixture
+def params_no_causal(recipe_config):
+    def _p(param_name, default=None):
+        return recipe_config.get(param_name, default)
+
+    causal_window = _p('causal_window')
+    window_unit = _p('window_unit')
+    window_width = int(_p('window_width'))
+    if _p('window_type') == 'none':
+        window_type = None
+    else:
+        window_type = _p('window_type')
+
+    if window_type == 'gaussian':
+        gaussian_std = _p('gaussian_std')
+    else:
+        gaussian_std = None
+
+    closed_option = _p('closed_option')
+    aggregation_types = _p('aggregation_types')
+
+    params = WindowAggregatorParams(window_unit=window_unit,
+                                    window_width=window_width,
+                                    window_type=window_type,
+                                    gaussian_std=gaussian_std,
+                                    closed_option=closed_option,
+                                    causal_window=causal_window,
+                                    aggregation_types=aggregation_types)
+
+    params.check()
+    return params
+
+class TestNoCausalWindow:
+    def test_no_causal_windows(self, monthly_df, params_no_causal, recipe_config):
+        window_aggregator = WindowAggregator(params_no_causal)
+        datetime_column = recipe_config.get('datetime_column')
+        output_df = window_aggregator.compute(monthly_df, datetime_column)
+        print(output_df)


### PR DESCRIPTION
[[ch62014]](https://app.clubhouse.io/dataiku/story/62014/windowing-and-extrema-extraction-fail-when-causal-window-is-not-selected-on-month-frequency-dataset)

# MTP
Build the flow of the following DSS [project](https://media.clubhouse.io/api/attachments/files/clubhouse-assets/5a072c19-2f6d-4f94-b436-0b60e21ff4a4/605b243d-9c07-437a-a352-b7525f142bd1/FREQUENCY_BUG.zip). 
See that each job fails. 

# Fix
I converted the data frequency into a rolling compatible time because yearly, weekly and annual frequencies were incompatible with the method `to_timedelta`. So, one year becomes 365 days, one week becomes 7 days and one month becomes 30 days similarly to the window description. 