### PR TITLE
Fix UI transition for ts identifiers 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,47 @@
+pipeline {
+   options { disableConcurrentBuilds() }
+   agent { label 'dss-plugin-tests'}
+   environment {
+        PLUGIN_INTEGRATION_TEST_INSTANCE="$HOME/instance_config.json"
+    }
+   stages {
+      stage('Run Unit Tests') {
+         steps {
+            sh 'echo "Running unit tests"'
+            catchError(stageResult: 'FAILURE') {
+            sh """
+               make unit-tests
+               """
+            }
+            sh 'echo "Done with unit tests"'
+         }
+      }
+      stage('Run Integration Tests') {
+         steps {
+            sh 'echo "Running integration tests"'
+            catchError(stageResult: 'FAILURE') {
+            sh """
+               make integration-tests
+               """
+            }
+            sh 'echo "Done with integration tests"'
+         }
+      }
+   }
+   post {
+     always {
+        script {
+           allure([
+                    includeProperties: false,
+                    jdk: '',
+                    properties: [],
+                    reportBuildPolicy: 'ALWAYS',
+                    results: [[path: 'tests/allure_report']]
+            ])
+
+            def status = currentBuild.currentResult
+            sh "file_name=\$(echo ${env.JOB_NAME} | tr '/' '-').status; touch \$file_name; echo \"${env.BUILD_URL};${env.CHANGE_TITLE};${env.CHANGE_AUTHOR};${env.CHANGE_URL};${env.BRANCH_NAME};${status};\" >> $HOME/daily-statuses/\$file_name"
+        }
+     }
+   }
+}

--- a/custom-recipes/timeseries-preparation-decomposition/recipe.json
+++ b/custom-recipes/timeseries-preparation-decomposition/recipe.json
@@ -319,7 +319,7 @@
         }
       ],
       "defaultValue": "additive",
-      "description": " If the magnitude of the seasonality varies over time, then the series is multiplicative. Otherwise, the series is additive."
+      "description": " If the magnitude of the seasonality varies over the average of the time series, then the series is multiplicative. Otherwise, the series is additive."
     },
     {
       "type": "SEPARATOR",

--- a/custom-recipes/timeseries-preparation-extrema-extraction/recipe.json
+++ b/custom-recipes/timeseries-preparation-extrema-extraction/recipe.json
@@ -56,7 +56,7 @@
       "type": "COLUMN",
       "columnRole": "input_dataset",
       "mandatory": false,
-      "description": "⚠️  Deprecated. Use the field 'Time series with identifiers' instead",
+      "description": "⚠️  Deprecated. Use the field 'Time series identifiers' instead",
       "visibilityCondition": "model.advanced_activated && (model.groupby_column.length > 0)"
     },
     {

--- a/custom-recipes/timeseries-preparation-extrema-extraction/recipe.json
+++ b/custom-recipes/timeseries-preparation-extrema-extraction/recipe.json
@@ -74,7 +74,7 @@
       ],
       "columnRole": "input_dataset",
       "mandatory": false,
-      "visibilityCondition": "model.advanced_activated && (model.groupby_column.length == 0 || !model.groupby_column)"
+      "visibilityCondition": "model.advanced_activated"
     },
     {
       "type": "SEPARATOR",

--- a/custom-recipes/timeseries-preparation-interval-extraction/recipe.json
+++ b/custom-recipes/timeseries-preparation-interval-extraction/recipe.json
@@ -56,7 +56,7 @@
       "type": "COLUMN",
       "columnRole": "input_dataset",
       "mandatory": false,
-      "description": "⚠️  Deprecated. Use the field 'Time series with identifiers' instead",
+      "description": "⚠️  Deprecated. Use the field 'Time series identifiers' instead",
       "visibilityCondition": "model.advanced_activated && (model.groupby_column.length > 0)"
     },
     {

--- a/custom-recipes/timeseries-preparation-interval-extraction/recipe.json
+++ b/custom-recipes/timeseries-preparation-interval-extraction/recipe.json
@@ -74,7 +74,7 @@
       ],
       "columnRole": "input_dataset",
       "mandatory": false,
-      "visibilityCondition": "model.advanced_activated && (model.groupby_column.length == 0 || !model.groupby_column)"
+      "visibilityCondition": "model.advanced_activated"
     },
     {
       "name": "sep",

--- a/custom-recipes/timeseries-preparation-resampling/recipe.json
+++ b/custom-recipes/timeseries-preparation-resampling/recipe.json
@@ -56,7 +56,7 @@
       "type": "COLUMN",
       "columnRole": "input_dataset",
       "mandatory": false,
-      "description": "⚠️  Deprecated. Use the field 'Time series with identifiers' instead",
+      "description": "⚠️  Deprecated. Use the field 'Time series identifiers' instead",
       "visibilityCondition": "model.advanced_activated && (model.groupby_column.length > 0)"
     },
     {

--- a/custom-recipes/timeseries-preparation-resampling/recipe.json
+++ b/custom-recipes/timeseries-preparation-resampling/recipe.json
@@ -74,7 +74,7 @@
       ],
       "columnRole": "input_dataset",
       "mandatory": false,
-      "visibilityCondition": "model.advanced_activated && (model.groupby_column.length == 0 || !model.groupby_column)"
+      "visibilityCondition": "model.advanced_activated"
     },
     {
       "name": "sep1",

--- a/custom-recipes/timeseries-preparation-windowing/recipe.json
+++ b/custom-recipes/timeseries-preparation-windowing/recipe.json
@@ -56,7 +56,7 @@
       "type": "COLUMN",
       "columnRole": "input_dataset",
       "mandatory": false,
-      "description": "⚠️  Deprecated. Use the field 'Time series with identifiers' instead",
+      "description": "⚠️  Deprecated. Use the field 'Time series identifiers' instead",
       "visibilityCondition": "model.advanced_activated && (model.groupby_column.length > 0)"
     },
     {

--- a/custom-recipes/timeseries-preparation-windowing/recipe.json
+++ b/custom-recipes/timeseries-preparation-windowing/recipe.json
@@ -74,7 +74,7 @@
       ],
       "columnRole": "input_dataset",
       "mandatory": false,
-      "visibilityCondition": "model.advanced_activated && (model.groupby_column.length == 0 || !model.groupby_column)"
+      "visibilityCondition": "model.advanced_activated"
     },
     {
       "name": "sep1",

--- a/python-lib/recipe_config_loading.py
+++ b/python-lib/recipe_config_loading.py
@@ -19,7 +19,7 @@ def check_and_get_groupby_columns(recipe_config, dataset_columns):
 
 
 def _format_groupby_columns(recipe_config):
-    if recipe_config.get('advanced_activated') and recipe_config.get('groupby_column'):
+    if recipe_config.get('advanced_activated') and recipe_config.get('groupby_column') and recipe_config.get('groupby_columns') is None:
         logger.warning(
             "The field `Column with identifier` is deprecated. It is now replaced with the field `Time series identifiers`, which allows for several "
             "identifiers. That is why you should preferably use the field 'Time series identifiers'. You can still use 'Column with identifier' if you "

--- a/python-lib/recipe_config_loading.py
+++ b/python-lib/recipe_config_loading.py
@@ -19,13 +19,16 @@ def check_and_get_groupby_columns(recipe_config, dataset_columns):
 
 
 def _format_groupby_columns(recipe_config):
-    if recipe_config.get('advanced_activated') and recipe_config.get('groupby_column') and recipe_config.get('groupby_columns') is None:
+    if recipe_config.get('advanced_activated') and recipe_config.get('groupby_column') and len(recipe_config.get('groupby_columns', [])) == 0:
         logger.warning(
             "The field `Column with identifier` is deprecated. It is now replaced with the field `Time series identifiers`, which allows for several "
             "identifiers. That is why you should preferably use the field 'Time series identifiers'. You can still use 'Column with identifier' if you "
             "have one identifier only")
         groupby_columns = [recipe_config.get('groupby_column')]
     elif recipe_config.get('advanced_activated') and recipe_config.get('groupby_columns'):
+        if recipe_config.get('groupby_column'):
+            logger.warning("The fields `Column with identifier` and `Time series identifiers` both contain a value. As `Column with identifiers`is deprecated, "
+                           "the recipe will only consider the value of `Time series identifiers`. ")
         groupby_columns = recipe_config.get('groupby_columns')
     else:
         groupby_columns = []

--- a/tests/python/unit/dku_timeseries/test_recipe_config_loading.py
+++ b/tests/python/unit/dku_timeseries/test_recipe_config_loading.py
@@ -54,3 +54,16 @@ class TestRecipeConfigLoading:
         config["groupby_columns"] = ["country"]
         groupby_colums = check_and_get_groupby_columns(config, dataset_columns)
         assert groupby_colums == ["country"]
+
+    def test_no_groupby_columns(self,config,dataset_columns):
+        config["groupby_columns"] =[]
+        config["groupby_column"] = "country"
+        groupby_colums = check_and_get_groupby_columns(config, dataset_columns)
+        assert len(groupby_colums) == 1
+
+        config.pop("groupby_columns")
+        groupby_colums = check_and_get_groupby_columns(config, dataset_columns)
+        assert len(groupby_colums) == 1
+
+
+

--- a/tests/python/unit/dku_timeseries/test_recipe_config_loading.py
+++ b/tests/python/unit/dku_timeseries/test_recipe_config_loading.py
@@ -12,18 +12,29 @@ def config():
     return config
 
 
+@pytest.fixture
+def dataset_columns():
+    return ["value1", "country", "old"]
+
+
 class TestRecipeConfigLoading:
     def test_check_and_get_groupby_columns(self, config):
         dataset_columns = ["value1", "country", "old"]
         groupby_colums = check_and_get_groupby_columns(config, dataset_columns)
         assert groupby_colums == ["country", "old"]
 
+        config.pop("groupby_columns")
+        config["groupby_column"] = "country"
+        groupby_colums = check_and_get_groupby_columns(config, dataset_columns)
+        assert groupby_colums == ["country"]
+
+    def test_invalid_groupby_columns(self, config, dataset_columns):
+        config["groupby_columns"] = ["country", ""]
         restricted_dataset_columns = ["value1", "country"]
         with pytest.raises(ValueError) as err:
             _ = check_and_get_groupby_columns(config, restricted_dataset_columns)
         assert "Invalid time series identifiers selection" in str(err.value)
 
-        config["groupby_columns"] = ["country", ""]
         with pytest.raises(ValueError) as err:
             _ = check_and_get_groupby_columns(config, restricted_dataset_columns)
         assert "Invalid time series identifiers selection" in str(err.value)
@@ -32,22 +43,14 @@ class TestRecipeConfigLoading:
         with pytest.raises(ValueError) as err:
             _ = check_and_get_groupby_columns(config, restricted_dataset_columns)
         assert "Long format is activated but no time series identifiers have been provided" in str(err.value)
-
-        config["groupby_column"] = "country"
-        groupby_colums = check_and_get_groupby_columns(config, dataset_columns)
-        assert groupby_colums == ["country"]
-
-        config["groupby_columns"] = ["notice"]
-        groupby_colums = check_and_get_groupby_columns(config, dataset_columns)
-        assert groupby_colums == ["country"]
 
         config["groupby_column"] = "not_ok"
         with pytest.raises(ValueError) as err:
             _ = check_and_get_groupby_columns(config, dataset_columns)
         assert "Invalid time series identifiers selection" in str(err.value)
 
-        config.pop("groupby_column")
-        config.pop("groupby_columns")
-        with pytest.raises(ValueError) as err:
-            _ = check_and_get_groupby_columns(config, dataset_columns)
-        assert "Long format is activated but no time series identifiers have been provided" in str(err.value)
+    def test_two_identifiers_fields(self, config, dataset_columns):
+        config["groupby_column"] = "notice"
+        config["groupby_columns"] = ["country"]
+        groupby_colums = check_and_get_groupby_columns(config, dataset_columns)
+        assert groupby_colums == ["country"]


### PR DESCRIPTION
[[ch62730]
](https://app.clubhouse.io/dataiku/story/62730/improve-the-transition-between-the-unique-select-groupby-column-and-the-multi-select-time-series-identifiers)
- Always display the `Time series identifiers` field
- When the two fields are used, keep the value of  `Time series identifiers` 