### PR TITLE
Deactivate pandas inference and check the target columns

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,47 @@
+pipeline {
+   options { disableConcurrentBuilds() }
+   agent { label 'dss-plugin-tests'}
+   environment {
+        PLUGIN_INTEGRATION_TEST_INSTANCE="$HOME/instance_config.json"
+    }
+   stages {
+      stage('Run Unit Tests') {
+         steps {
+            sh 'echo "Running unit tests"'
+            catchError(stageResult: 'FAILURE') {
+            sh """
+               make unit-tests
+               """
+            }
+            sh 'echo "Done with unit tests"'
+         }
+      }
+      stage('Run Integration Tests') {
+         steps {
+            sh 'echo "Running integration tests"'
+            catchError(stageResult: 'FAILURE') {
+            sh """
+               make integration-tests
+               """
+            }
+            sh 'echo "Done with integration tests"'
+         }
+      }
+   }
+   post {
+     always {
+        script {
+           allure([
+                    includeProperties: false,
+                    jdk: '',
+                    properties: [],
+                    reportBuildPolicy: 'ALWAYS',
+                    results: [[path: 'tests/allure_report']]
+            ])
+
+            def status = currentBuild.currentResult
+            sh "file_name=\$(echo ${env.JOB_NAME} | tr '/' '-').status; touch \$file_name; echo \"${env.BUILD_URL};${env.CHANGE_TITLE};${env.CHANGE_AUTHOR};${env.CHANGE_URL};${env.BRANCH_NAME};${status};\" >> $HOME/daily-statuses/\$file_name"
+        }
+     }
+   }
+}

--- a/custom-recipes/timeseries-preparation-decomposition/recipe.py
+++ b/custom-recipes/timeseries-preparation-decomposition/recipe.py
@@ -23,7 +23,7 @@ input_dataset_columns = [column["name"] for column in input_dataset.read_schema(
 (dku_config, input_validator, decomposition) = check_and_load_params(config, input_dataset_columns)
 
 timeseries_preparator = TimeseriesPreparator(dku_config)
-input_df = input_dataset.get_dataframe()
+input_df = input_dataset.get_dataframe(infer_with_pandas=False)
 df_prepared = timeseries_preparator.prepare_timeseries_dataframe(input_df)
 input_validator.check(df_prepared)
 

--- a/python-lib/dku_config/decomposition_config.py
+++ b/python-lib/dku_config/decomposition_config.py
@@ -61,15 +61,15 @@ class DecompositionConfig(DkuConfig):
                      }],
             required=True
         )
-
-        if config.get("frequency_unit") == "W":
+        frequency_unit = config.get("frequency_unit")
+        if frequency_unit == "W":
             frequency_value = f"W-{config.get('frequency_end_of_week', 'SUN')}"
-        elif config.get("frequency_unit") == "H":
+        elif frequency_unit == "H":
             frequency_value = f"{config.get('frequency_step_hours', 1)}H"
-        elif config.get("frequency_unit") == "min":
+        elif frequency_unit == "min":
             frequency_value = f"{config.get('frequency_step_minutes', 1)}min"
         else:
-            frequency_value = config.get("frequency_unit")
+            frequency_value = frequency_unit
 
         self.add_param(
             name="frequency",
@@ -77,7 +77,7 @@ class DecompositionConfig(DkuConfig):
             checks=[
                 {"type": "custom",
                  "op": frequency_value in ["D", "min", "12M", "3M", "6M", "M", "W", "B", "H"] or frequency_value.startswith("W") or frequency_value.endswith(
-                     "H") or frequency_value.startswith("min")
+                     "H") or frequency_value.endswith("min")
                  }
             ],
             required=True
@@ -85,13 +85,13 @@ class DecompositionConfig(DkuConfig):
 
         if frequency_value:
             if frequency_value == "min" or frequency_value == "12M" or frequency_value.endswith("min"):
-                period_value = config.get(f"season_length_{frequency_value}", 1)
+                period_value = config.get(f"season_length_{frequency_unit}", 1)
             elif frequency_value == "6M":
-                period_value = config.get(f"season_length_{frequency_value}", 2)
+                period_value = config.get(f"season_length_{frequency_unit}", 2)
             elif frequency_value == "3M":
-                period_value = config.get(f"season_length_{frequency_value}", 4)
+                period_value = config.get(f"season_length_{frequency_unit}", 4)
             else:
-                period_value = config.get(f"season_length_{frequency_value}", freq_to_period(frequency_value))
+                period_value = config.get(f"season_length_{frequency_unit}", freq_to_period(frequency_value))
                 if not config.get(f"season_length_{frequency_value}"):
                     logger.warning(f"The recipe relies on the default period = {period_value} for a frequency = {frequency_value}.")
 

--- a/python-lib/timeseries_preparation/preparation.py
+++ b/python-lib/timeseries_preparation/preparation.py
@@ -82,7 +82,8 @@ class TimeseriesPreparator:
             except Exception:
                 invalid_target_columns.append(target_column)
         if len(invalid_target_columns) > 0:
-            raise ValueError(f"Target columns must be numeric. Please parse the target column(s) '{','.join(invalid_target_columns)}' in a Prepare recipe")
+            raise ValueError(f"Target columns must be numeric. Please check the validity of the target column(s) '{','.join(invalid_target_columns)}' in the "
+                             f"settings.")
         else:
             return df
 

--- a/python-lib/timeseries_preparation/preparation.py
+++ b/python-lib/timeseries_preparation/preparation.py
@@ -45,6 +45,8 @@ class TimeseriesPreparator:
         except Exception:
             raise ValueError(f"Please parse the date column '{self.time_column_name}' in a Prepare recipe")
 
+        dataframe_prepared = self._cast_target_columns(dataframe_prepared)
+
         dataframe_prepared = self._truncate_dates(dataframe_prepared)
 
         dataframe_prepared = self._sort(dataframe_prepared)
@@ -63,6 +65,26 @@ class TimeseriesPreparator:
     def _check_data(self, df):
         self._check_timeseries_identifiers_columns_types(df)
         self._check_no_missing_values(df)
+
+    def _cast_target_columns(self, df):
+        """Cast target columns as float as the pandas inference is deactivated.
+        Args:
+            df (DataFrame)
+        Raises:
+            ValueError: If the column contains non numeric or empty data
+        Returns:
+            Sorted DataFrame with truncated dates.
+        """
+        invalid_target_columns = []
+        for target_column in self.target_columns_names:
+            try:
+                df[target_column] = df[target_column].astype("float")
+            except Exception:
+                invalid_target_columns.append(target_column)
+        if len(invalid_target_columns) > 0:
+            raise ValueError(f"Target columns must be numeric. Please parse the target column(s) '{','.join(invalid_target_columns)}' in a Prepare recipe")
+        else:
+            return df
 
     def _truncate_dates(self, df):
         """Truncate dates to selected frequency. For Week/Month/Year, truncate to end of Week/Month/Year.

--- a/tests/python/unit/dku_config/test_decomposition_config.py
+++ b/tests/python/unit/dku_config/test_decomposition_config.py
@@ -102,6 +102,40 @@ class TestDecompositionConfig:
         min_config_30 = config_from_freq("min", frequency_step_minutes=30)
         assert min_config_30.period == 1
 
+    def test_frequencies_with_season_lengths(self):
+        annual_config = config_with_period_from_freq("12M")
+        assert annual_config.period == 5
+
+        quarterly_config = config_with_period_from_freq("3M")
+        assert quarterly_config.period == 5
+
+        semiannual_config = config_with_period_from_freq("6M")
+        assert semiannual_config.period == 5
+
+        monthly_config = config_with_period_from_freq("M")
+        assert monthly_config.period == 5
+
+        weekly_config = config_with_period_from_freq("W", frequency_end_of_week="WED")
+        assert weekly_config.period == 5
+
+        b_weekly_config = config_with_period_from_freq("B")
+        assert b_weekly_config.period == 5
+
+        hourly_config = config_with_period_from_freq("H")
+        assert hourly_config.period == 5
+
+        hourly_config_3 = config_with_period_from_freq("H", frequency_step_hours=3)
+        assert hourly_config_3.period == 5
+
+        daily_config = config_with_period_from_freq("D")
+        assert daily_config.period == 5
+
+        min_config = config_with_period_from_freq("min")
+        assert min_config.period == 5
+
+        min_config_30 = config_with_period_from_freq("min", frequency_step_minutes=30)
+        assert min_config_30.period == 5
+
 
 def config_from_freq(freq, frequency_end_of_week=None, frequency_step_hours=None, frequency_step_minutes=None):
     config = {"transformation_type": "seasonal_decomposition", "time_decomposition_method": "STL",
@@ -114,6 +148,23 @@ def config_from_freq(freq, frequency_end_of_week=None, frequency_step_hours=None
     elif frequency_step_minutes:
         config["frequency_step_minutes"] = frequency_step_minutes
     input_dataset_columns = ["value1", "value2", "country", "date"]
+    dku_config = DecompositionConfig()
+    dku_config.add_parameters(config, input_dataset_columns)
+    return dku_config
+
+
+def config_with_period_from_freq(freq, frequency_end_of_week=None, frequency_step_hours=None, frequency_step_minutes=None):
+    config = {"transformation_type": "seasonal_decomposition", "time_decomposition_method": "STL",
+              "frequency_unit": freq, "time_column": "date", "target_columns": ["value1"],
+              "long_format": False, "decomposition_model": "multiplicative", "expert": False}
+    if frequency_end_of_week:
+        config["frequency_end_of_week"] = frequency_end_of_week
+    elif frequency_step_hours:
+        config["frequency_step_hours"] = frequency_step_hours
+    elif frequency_step_minutes:
+        config["frequency_step_minutes"] = frequency_step_minutes
+    input_dataset_columns = ["value1", "value2", "country", "date"]
+    config[f"season_length_{freq}"] = 5
     dku_config = DecompositionConfig()
     dku_config.add_parameters(config, input_dataset_columns)
     return dku_config

--- a/tests/python/unit/test_timeseries_preparation.py
+++ b/tests/python/unit/test_timeseries_preparation.py
@@ -1,0 +1,270 @@
+import pandas as pd
+import pytest
+
+from dku_config.stl_config import STLConfig
+from timeseries_preparation.preparation import TimeseriesPreparator
+
+
+@pytest.fixture
+def time_column_name():
+    return "date"
+
+
+@pytest.fixture
+def timeseries_identifiers_names():
+    return ["id"]
+
+
+@pytest.fixture
+def basic_config(time_column_name):
+    config = {"transformation_type": "seasonal_decomposition", "time_decomposition_method": "STL",
+              "frequency_unit": "M", "season_length_M": 12, "time_column": time_column_name, "target_columns": ["target"],
+              "long_format": False, "decomposition_model": "multiplicative", "expert": False}
+    return config
+
+
+def test_duplicate_dates(time_column_name, timeseries_identifiers_names, basic_config):
+    df = pd.DataFrame(
+        {
+            "date": [
+                "2021-01-01 12:12:00",
+                "2021-01-01 17:35:00",
+                "2021-01-02 14:55:00",
+            ],
+            "id": [1, 1, 1],
+            "target": [1, 2, 3]
+        }
+    )
+    dku_config = STLConfig()
+    basic_config["frequency"] = "D"
+    dku_config.add_parameters(basic_config, list(df.columns))
+    df[time_column_name] = pd.to_datetime(df[time_column_name]).dt.tz_localize(tz=None)
+    preparator = TimeseriesPreparator(dku_config)
+    with pytest.raises(ValueError):
+        _ = preparator._truncate_dates(df)
+
+
+def test_minutes_truncation(time_column_name, basic_config):
+    df = pd.DataFrame(
+        {
+            "date": [
+                "2021-01-01 12:17:42",
+                "2021-01-01 12:30:00",
+                "2021-01-01 12:46:00",
+            ],
+            "id": [1, 1, 1],
+            "target": [1, 2, 3]
+        }
+    )
+    dku_config = STLConfig()
+    basic_config["frequency_step_minutes"] = "15"
+    basic_config["frequency_unit"] = "min"
+    basic_config["season_length_min"] = 4
+    dku_config.add_parameters(basic_config, list(df.columns))
+    df[time_column_name] = pd.to_datetime(df[time_column_name]).dt.tz_localize(tz=None)
+    preparator = TimeseriesPreparator(dku_config)
+    dataframe_prepared = preparator._truncate_dates(df)
+    dataframe_prepared = preparator._sort(dataframe_prepared)
+    preparator._check_regular_frequency(dataframe_prepared)
+
+    assert dataframe_prepared[time_column_name][0] == pd.Timestamp("2021-01-01  12:15:00")
+    assert dataframe_prepared[time_column_name][2] == pd.Timestamp("2021-01-01 12:45:00")
+
+
+def test_hour_truncation(time_column_name,timeseries_identifiers_names, basic_config):
+    df = pd.DataFrame(
+        {
+            "date": [
+                "2020-01-07 12:12:00",
+                "2020-01-07 17:35:00",
+                "2020-01-07 14:55:00",
+                "2020-01-07 18:06:00",
+                "2020-01-08 04:40:00",
+                "2020-01-08 06:13:00",
+                "2020-01-08 03:23:00",
+            ],
+            "id": [1, 1, 1, 1, 2, 2, 2],
+            "target": [1, 2, 3, 4, 5, 6, 7]
+        }
+    )
+    df[time_column_name] = pd.to_datetime(df[time_column_name]).dt.tz_localize(tz=None)
+    dku_config = STLConfig()
+    basic_config["frequency_step_hours"] = "2"
+    basic_config["frequency_unit"] = "H"
+    basic_config["long_format"] = True
+    basic_config["timeseries_identifiers"] = timeseries_identifiers_names
+    dku_config.add_parameters(basic_config, list(df.columns))
+    preparator = TimeseriesPreparator(dku_config,max_timeseries_length = 2)
+    dataframe_prepared = preparator._truncate_dates(df)
+    dataframe_prepared = preparator._sort(dataframe_prepared)
+    preparator._check_regular_frequency(dataframe_prepared)
+    dataframe_prepared = preparator._keep_last_dates(dataframe_prepared)
+    assert dataframe_prepared[time_column_name][0] == pd.Timestamp("2020-01-07 16:00:00")
+    assert dataframe_prepared[time_column_name][3] == pd.Timestamp("2020-01-08 06:00:00")
+
+
+def test_day_truncation(time_column_name,timeseries_identifiers_names, basic_config):
+    df = pd.DataFrame(
+        {
+            "date": [
+                "2021-01-01 12:17:42",
+                "2021-01-02 00:00:00",
+                "2021-01-03 12:46:00",
+            ],
+            "id": [1, 1, 1],
+            "target": [1, 2, 3]
+        }
+    )
+    dku_config = STLConfig()
+    basic_config["frequency_unit"] = "D"
+    basic_config["long_format"] = True
+    basic_config["timeseries_identifiers"] = timeseries_identifiers_names
+    dku_config.add_parameters(basic_config, list(df.columns))
+    preparator = TimeseriesPreparator(dku_config)
+    df[time_column_name] = pd.to_datetime(df[time_column_name]).dt.tz_localize(tz=None)
+    dataframe_prepared = preparator._truncate_dates(df)
+    dataframe_prepared = preparator._sort(dataframe_prepared)
+    preparator._check_regular_frequency(dataframe_prepared)
+
+    assert dataframe_prepared[time_column_name][0] == pd.Timestamp("2021-01-01")
+    assert dataframe_prepared[time_column_name][2] == pd.Timestamp("2021-01-03")
+
+
+def test_business_day_truncation(time_column_name,timeseries_identifiers_names, basic_config):
+    df = pd.DataFrame(
+        {
+            "date": [
+                "2021-01-04 12:17:42",
+                "2021-01-05 00:00:00",
+                "2021-01-06 12:46:00",
+            ],
+            "id": [1, 1, 1],
+            "target": [1, 2, 3]
+        }
+    )
+    dku_config = STLConfig()
+    basic_config["frequency_unit"] = "B"
+    basic_config["long_format"] = True
+    basic_config["timeseries_identifiers"] = timeseries_identifiers_names
+    dku_config.add_parameters(basic_config, list(df.columns))
+    preparator = TimeseriesPreparator(dku_config)
+    df[time_column_name] = pd.to_datetime(df[time_column_name]).dt.tz_localize(tz=None)
+    dataframe_prepared = preparator._truncate_dates(df)
+    dataframe_prepared = preparator._sort(dataframe_prepared)
+    preparator._check_regular_frequency(dataframe_prepared)
+
+    assert dataframe_prepared[time_column_name][0] == pd.Timestamp("2021-01-04")
+    assert dataframe_prepared[time_column_name][2] == pd.Timestamp("2021-01-06")
+
+
+def test_week_sunday_truncation(time_column_name,timeseries_identifiers_names, basic_config):
+    df = pd.DataFrame(
+        {
+            "date": [
+                "2021-01-03 12:12:00",
+                "2021-01-05 17:35:00",
+                "2021-01-15 14:55:00",
+            ],
+            "id": [1, 1, 1],
+            "target": [1, 2, 3]
+        }
+    )
+    dku_config = STLConfig()
+    basic_config["frequency_unit"] = "W"
+    basic_config["frequency_end_of_week"] = "SUN"
+    basic_config["long_format"] = True
+    basic_config["timeseries_identifiers"] = timeseries_identifiers_names
+    dku_config.add_parameters(basic_config, list(df.columns))
+    preparator = TimeseriesPreparator(dku_config,max_timeseries_length=2)
+    df[time_column_name] = pd.to_datetime(df[time_column_name]).dt.tz_localize(tz=None)
+    dataframe_prepared = preparator._truncate_dates(df)
+    dataframe_prepared = preparator._sort(dataframe_prepared)
+    preparator._check_regular_frequency(dataframe_prepared)
+
+    dataframe_prepared = preparator._keep_last_dates(dataframe_prepared)
+    assert dataframe_prepared[time_column_name][0] == pd.Timestamp("2021-01-10")
+    assert dataframe_prepared[time_column_name][1] == pd.Timestamp("2021-01-17")
+
+
+def test_quarter_truncation(time_column_name,timeseries_identifiers_names, basic_config):
+    df = pd.DataFrame(
+        {
+            "date": [
+                "2020-12-15",
+                "2021-03-28",
+                "2021-06-11",
+            ],
+            "id": [1, 1, 1],
+            "target": [1, 2, 3]
+        }
+    )
+    dku_config = STLConfig()
+    basic_config["frequency_unit"] = "3M"
+    basic_config["long_format"] = True
+    basic_config["timeseries_identifiers"] = timeseries_identifiers_names
+    dku_config.add_parameters(basic_config, list(df.columns))
+    preparator = TimeseriesPreparator(dku_config)
+    df[time_column_name] = pd.to_datetime(df[time_column_name]).dt.tz_localize(tz=None)
+    dataframe_prepared = preparator._truncate_dates(df)
+    dataframe_prepared = preparator._sort(dataframe_prepared)
+    preparator._check_regular_frequency(dataframe_prepared)
+
+    assert dataframe_prepared[time_column_name][0] == pd.Timestamp("2020-12-31")
+    assert dataframe_prepared[time_column_name][2] == pd.Timestamp("2021-06-30")
+
+
+def test_semester_truncation(time_column_name,timeseries_identifiers_names, basic_config):
+    df = pd.DataFrame(
+        {
+            "date": [
+                "2020-12-15",
+                "2021-06-28",
+                "2021-12-01",
+            ],
+            "id": [1, 1, 1],
+            "target": [1, 2, 3]
+        }
+    )
+    dku_config = STLConfig()
+    basic_config["frequency_unit"] = "6M"
+    basic_config["long_format"] = True
+    basic_config["timeseries_identifiers"] = timeseries_identifiers_names
+    dku_config.add_parameters(basic_config, list(df.columns))
+    preparator = TimeseriesPreparator(dku_config)
+    df[time_column_name] = pd.to_datetime(df[time_column_name]).dt.tz_localize(tz=None)
+    dataframe_prepared = preparator._truncate_dates(df)
+    dataframe_prepared = preparator._sort(dataframe_prepared)
+    preparator._check_regular_frequency(dataframe_prepared)
+
+    assert dataframe_prepared[time_column_name][0] == pd.Timestamp("2020-12-31")
+    assert dataframe_prepared[time_column_name][1] == pd.Timestamp("2021-06-30")
+    assert dataframe_prepared[time_column_name][2] == pd.Timestamp("2021-12-31")
+
+
+def test_year_truncation(time_column_name,timeseries_identifiers_names, basic_config):
+    df = pd.DataFrame(
+        {
+            "date": [
+                "2020-12-31",
+                "2021-12-15",
+                "2022-12-01",
+            ],
+            "id": [1, 1, 1],
+            "target": [1, 2, 3]
+        }
+    )
+    dku_config = STLConfig()
+    basic_config["frequency_unit"] = "12M"
+    basic_config["long_format"] = True
+    basic_config["timeseries_identifiers"] = timeseries_identifiers_names
+    basic_config["season_length_12M"] = 4
+    dku_config.add_parameters(basic_config, list(df.columns))
+    preparator = TimeseriesPreparator(dku_config)
+    df[time_column_name] = pd.to_datetime(df[time_column_name]).dt.tz_localize(tz=None)
+    dataframe_prepared = preparator._truncate_dates(df)
+    dataframe_prepared = preparator._sort(dataframe_prepared)
+    preparator._check_regular_frequency(dataframe_prepared)
+
+    assert dataframe_prepared[time_column_name][0] == pd.Timestamp("2020-12-31")
+    assert dataframe_prepared[time_column_name][1] == pd.Timestamp("2021-12-31")
+    assert dataframe_prepared[time_column_name][2] == pd.Timestamp("2022-12-31")

--- a/tests/python/unit/test_timeseries_preparation.py
+++ b/tests/python/unit/test_timeseries_preparation.py
@@ -304,5 +304,26 @@ def test_target_column_preparation(time_column_name, timeseries_identifiers_name
     df_prepared_unformatted = preparator.prepare_timeseries_dataframe(df)
     assert df_prepared_unformatted.loc[0, "unformatted_target"] == 1
 
+    dku_config = STLConfig()
+    basic_config["target_columns"] = ["invalid_target"]
+    basic_config["frequency_unit"] = "12M"
+    basic_config["season_length_12M"] = 4
+    dku_config.add_parameters(basic_config, list(df.columns))
+    preparator = TimeseriesPreparator(dku_config)
+    with pytest.raises(ValueError) as err:
+        _ = preparator.prepare_timeseries_dataframe(df)
+    assert "must be numeric" in str(err.value)
+
+    dku_config = STLConfig()
+    basic_config["target_columns"] = ["missing_target"]
+    basic_config["frequency_unit"] = "12M"
+    basic_config["season_length_12M"] = 4
+    dku_config.add_parameters(basic_config, list(df.columns))
+    preparator = TimeseriesPreparator(dku_config)
+    with pytest.raises(ValueError) as err:
+        _ = preparator.prepare_timeseries_dataframe(df)
+    assert "missing value" in str(err.value)
+
+
 
 


### PR DESCRIPTION
- [[ch62784]](https://app.clubhouse.io/dataiku/story/62784/deactivate-infer-with-pandas-in-the-get-dataframe-of-the-input-dataset) - Deactivate pd inference

- Check the type of the input target column
- Fix a bug with the period for H and min frequencies (use frequency_unit instead of frequency_value)

