### PR TITLE
Include integration tests on dku 34

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,14 @@ unit-tests:
 
 integration-tests:
 	@echo "Running integration tests..."
+	@( \
+		rm -rf ./env/; \
+		python3 -m venv env/; \
+		source env/bin/activate; \
+		pip3 install --upgrade pip;\
+		pip install --no-cache-dir -r tests/python/integration/requirements.txt; \
+		pytest tests/python/integration --alluredir=tests/allure_report || ret=$$?; exit $$ret \
+	)
 
 tests: unit-tests integration-tests
 

--- a/tests/python/integration/requirements.txt
+++ b/tests/python/integration/requirements.txt
@@ -1,0 +1,3 @@
+pytest==6.2.1
+dataiku-api-client
+git+git://github.com/dataiku/dataiku-plugin-tests-utils.git@master#egg=dataiku-plugin-tests-utils

--- a/tests/python/integration/test_scenario.py
+++ b/tests/python/integration/test_scenario.py
@@ -1,0 +1,23 @@
+from dku_plugin_test_utils import dss_scenario
+
+project_key = "Plugin_Test_TsPrep"
+
+
+def test_resampling(user_dss_clients):
+    dss_scenario.run(client=user_dss_clients, project_key=project_key, scenario_id="Run_resampling")
+
+
+def test_windowing(user_dss_clients):
+    dss_scenario.run(client=user_dss_clients, project_key=project_key, scenario_id="Windowing")
+
+
+def test_extrema_extraction(user_dss_clients):
+    dss_scenario.run(client=user_dss_clients, project_key=project_key, scenario_id="Extrema")
+
+
+def test_interval_extraction(user_dss_clients):
+    dss_scenario.run(client=user_dss_clients, project_key=project_key, scenario_id="Intervals")
+
+
+def test_decomposition(user_dss_clients):
+    dss_scenario.run(client=user_dss_clients, project_key=project_key, scenario_id="Decomposition")

--- a/tests/python/integration/tests/python/integration/pytest.ini
+++ b/tests/python/integration/tests/python/integration/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+usefixtures = plugin dss_target


### PR DESCRIPTION
[[ch61564]
](https://app.clubhouse.io/dataiku/story/61564/integration-tests-for-the-ts-preparation-plugin)

In addition to [dip’s integration tests](https://github.com/dataiku/dip/pull/12542), I developed more “traditional” plugin integration tests with a test project on dku 34. So I added the required files to perform those tests.  