### PR TITLE
Fix V2 regression when the options "don't interpolate" and "don't extrapolate" are selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## Version 2.0.1 - Bugfix release - 2021-06
-- :bug: Fix regression when the user chooses "no interpolation" or "no extrapolation". Keep the empty values rather than filtering them. 
+- :bug: Keep the empty values rather than filtering them with the extrapolation method "Empty"
+- :scissors: Add the extrapolation method "Do nothing" to filter missing values
 - :pencil: Edit plugin.json to reflect the changes made in 2.0.0
 
 ## Version 2.0.0 - New feature and bugfix release - 2021-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
 ## Version 2.0.1 - Bugfix release - 2021-06
-- :bug: Keep the empty values rather than filtering them with the extrapolation method "Empty"
-- :scissors: Add the extrapolation method "Do nothing" to filter missing values
+- :bug: Keep the empty values rather than filtering them with the extrapolation method "Don't extrapolate (impute nulls)"
+- :scissors: Add the extrapolation method "Don't extrapolate (no imputation)" to filter missing values
 - :pencil: Edit plugin.json to reflect the changes made in 2.0.0
 
 ## Version 2.0.0 - New feature and bugfix release - 2021-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Version 2.0.1 - Bugfix release - 2021-06
+- :bug: Fix regression when the user chooses "no interpolation" or "no extrapolation". Keep the empty values rather than filtering them. 
 - :pencil: Edit plugin.json to reflect the changes made in 2.0.0
 
 ## Version 2.0.0 - New feature and bugfix release - 2021-05

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -2,4 +2,4 @@ scipy==1.2.1
 pandas==0.23.4
 numpy==1.16.4
 future==0.18.2
-statsmodels==0.12.2;python_version>"3"
+statsmodels==0.12.2

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -2,4 +2,4 @@ scipy==1.2.1
 pandas==0.23.4
 numpy==1.16.4
 future==0.18.2
-statsmodels==0.12.2
+statsmodels==0.12.2;python_version>"3"

--- a/custom-recipes/timeseries-preparation-resampling/recipe.json
+++ b/custom-recipes/timeseries-preparation-resampling/recipe.json
@@ -260,6 +260,10 @@
         {
           "value": "none",
           "label": "Empty"
+        },
+        {
+          "value": "no_extrapolation",
+          "label": "Do nothing"
         }
       ],
       "defaultValue": "clip"

--- a/custom-recipes/timeseries-preparation-resampling/recipe.json
+++ b/custom-recipes/timeseries-preparation-resampling/recipe.json
@@ -231,7 +231,7 @@
         },
         {
           "value": "none",
-          "label": "Don't interpolate (no value)"
+          "label": "Empty"
         }
       ],
       "defaultValue": "linear"
@@ -259,7 +259,7 @@
         },
         {
           "value": "none",
-          "label": "Don't extrapolate (no value)"
+          "label": "Empty"
         }
       ],
       "defaultValue": "clip"

--- a/custom-recipes/timeseries-preparation-resampling/recipe.json
+++ b/custom-recipes/timeseries-preparation-resampling/recipe.json
@@ -231,7 +231,7 @@
         },
         {
           "value": "none",
-          "label": "Empty"
+          "label": "Don't extrapolate (impute null)"
         }
       ],
       "defaultValue": "linear"
@@ -259,11 +259,11 @@
         },
         {
           "value": "none",
-          "label": "Empty"
+          "label": "Don't extrapolate (impute null)"
         },
         {
           "value": "no_extrapolation",
-          "label": "Do nothing"
+          "label": "Don't extrapolate (no imputation)"
         }
       ],
       "defaultValue": "clip"

--- a/python-lib/dku_timeseries/resampling.py
+++ b/python-lib/dku_timeseries/resampling.py
@@ -10,7 +10,7 @@ from dku_timeseries.timeseries_helpers import FREQUENCY_STRINGS, generate_date_r
 logger = logging.getLogger(__name__)
 
 INTERPOLATION_METHODS = ['linear', 'nearest', 'slinear', 'zero', 'quadratic', 'cubic', 'previous', 'next', 'constant', 'none']
-EXTRAPOLATION_METHODS = ['none', 'clip', 'interpolation']
+EXTRAPOLATION_METHODS = ['none', 'clip', 'interpolation', 'no_extrapolation']
 CATEGORY_IMPUTATION_METHODS = ['empty', 'constant', 'previous', 'next', 'clip', 'mode']
 TIME_UNITS = list(FREQUENCY_STRINGS.keys()) + ['rows']
 
@@ -191,6 +191,8 @@ class Resampler:
             if self.params.extrapolation_method == "clip":
                 temp_df = df_resample.copy().ffill().bfill()
                 df_resample.loc[extrapolation_index, filtered_column] = temp_df.loc[extrapolation_index, filtered_column]
+            elif self.params.extrapolation_method == "no_extrapolation":
+                reference_index = reference_index[~reference_index.isin(extrapolation_index.values)]
             category_imputation_index = category_imputation_index.union(extrapolation_index).union(interpolation_index)
 
         if len(category_columns) > 0 and len(category_imputation_index) > 0 and self.params.category_imputation_method != "empty":

--- a/python-lib/dku_timeseries/resampling.py
+++ b/python-lib/dku_timeseries/resampling.py
@@ -197,7 +197,6 @@ class Resampler:
             df_processed = df_resample.loc[category_imputation_index]
             df_resample.loc[category_imputation_index] = self._fill_in_category_values(df_processed, category_columns)
         df_resampled = df_resample.loc[reference_index].drop('numerical_index', axis=1)
-        df_resampled.dropna(subset=filtered_columns_to_resample, inplace=True)
         return df_resampled
 
     def _fill_in_category_values(self, df, category_columns):

--- a/tests/python/unit/dku_timeseries/resampling/test_resampling.py
+++ b/tests/python/unit/dku_timeseries/resampling/test_resampling.py
@@ -3,6 +3,7 @@ import random
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from dku_timeseries.resampling import ResamplerParams, Resampler
 
@@ -14,6 +15,38 @@ JUST_BEFORE_FALL_DST = pd.Timestamp('20191027 02:59:00').tz_localize('CET',
 TIME_COL = 'time_col'
 DATA_COL = 'data_col'
 GROUP_COL = 'group_col'
+
+
+@pytest.fixture
+def academy_orders_df():
+    dates = pd.DatetimeIndex(['2013-03-29T00:00:00.000000000', '2013-04-10T00:00:00.000000000',
+                              '2013-04-19T00:00:00.000000000', '2013-04-23T00:00:00.000000000',
+                              '2013-04-25T00:00:00.000000000', '2013-04-30T00:00:00.000000000',
+                              '2013-05-03T00:00:00.000000000', '2013-05-04T00:00:00.000000000',
+                              '2013-05-07T00:00:00.000000000', '2013-05-08T00:00:00.000000000',
+                              '2013-05-09T00:00:00.000000000', '2013-05-11T00:00:00.000000000',
+                              '2013-05-12T00:00:00.000000000', '2013-05-13T00:00:00.000000000',
+                              '2013-05-14T00:00:00.000000000', '2013-05-15T00:00:00.000000000',
+                              '2013-05-15T00:00:00.000000000', '2013-05-17T00:00:00.000000000',
+                              '2013-05-17T00:00:00.000000000', '2013-05-18T00:00:00.000000000',
+                              '2013-05-19T00:00:00.000000000', '2013-05-20T00:00:00.000000000',
+                              '2013-05-20T00:00:00.000000000', '2013-05-21T00:00:00.000000000',
+                              '2013-05-22T00:00:00.000000000', '2013-05-22T00:00:00.000000000',
+                              '2013-05-24T00:00:00.000000000', '2013-05-28T00:00:00.000000000',
+                              '2013-05-28T00:00:00.000000000', '2013-05-28T00:00:00.000000000',
+                              '2013-05-29T00:00:00.000000000'])
+    tshirt_quantity = [1, 4, 3, 4, 1, 3, 2, 5, 2, 2, 1, 1, 2, 4, 2, 1, 1, 1, 4, 7, 2, 1,
+                       1, 1, 1, 2, 3, 2, 5, 4, 3]
+    tshirt_category = ['Black T-Shirt M', 'White T-Shirt M', 'Hoodie', 'White T-Shirt F',
+                       'White T-Shirt M', 'Black T-Shirt M', 'White T-Shirt M',
+                       'Black T-Shirt M', 'Hoodie', 'White T-Shirt F', 'White T-Shirt F',
+                       'Black T-Shirt M', 'Hoodie', 'Hoodie', 'Tennis Shirt', 'Hoodie',
+                       'White T-Shirt M', 'Hoodie', 'White T-Shirt M', 'Black T-Shirt M',
+                       'White T-Shirt M', 'Black T-Shirt M', 'White T-Shirt F',
+                       'Black T-Shirt F', 'Black T-Shirt F', 'White T-Shirt F', 'Hoodie',
+                       'Black T-Shirt M', 'Hoodie', 'Black T-Shirt F', 'Hoodie']
+    df_orders = pd.DataFrame({TIME_COL: dates, DATA_COL: tshirt_quantity, GROUP_COL: tshirt_category})
+    return df_orders
 
 
 ### Helpers to create test data, should be fixtures at some point I guess
@@ -245,34 +278,53 @@ class TestResampler:
         resample_data_1 = output_df.groupby(GROUP_COL).get_group('group_1').data_col.values
         assert np.array_equal(resample_data_1, ref_data_1)
 
-    def test_no_empty_rows(self):
-        # [ch61615] The recipe should not add empty rows when there is no extrapolation
+    def test_empty_extrapolation_month(self):
         length = 10
         data = [random.random() for _ in range(length)]
         start_time = pd.Timestamp('20210101 00:00:00').tz_localize('CET')
-        df = _make_df_with_one_col(data, period=pd.DateOffset(months=1), start_time=start_time)
+        df_start_of_month = _make_df_with_one_col(data, period=pd.DateOffset(months=1), start_time=start_time)
         params = ResamplerParams(time_unit="months", extrapolation_method='none')
         resampler = Resampler(params)
-        output_df = resampler.transform(df, TIME_COL)
+        output_df = resampler.transform(df_start_of_month, TIME_COL)
         assert not math.isnan(output_df["data_col"].values[0])
-        assert not math.isnan(output_df["data_col"].values[-1])
+        assert math.isnan(output_df["data_col"].values[-1])
 
-        df = _make_df_with_one_col(data, period=pd.DateOffset(months=1))
+        df_end_of_month = _make_df_with_one_col(data, period=pd.DateOffset(months=1))
         params = ResamplerParams(time_unit="months", extrapolation_method="none")
         resampler = Resampler(params)
-        output_df = resampler.transform(df, TIME_COL)
-        assert not math.isnan(output_df["data_col"].values[-1])
+        output_df = resampler.transform(df_end_of_month, TIME_COL)
+        assert math.isnan(output_df["data_col"].values[-1])
 
-    def test_no_end_of_week(self):
+    def test_empty_extrapolation_week(self):
         length = 10
         data = [random.random() for _ in range(length)]
         start_time = pd.Timestamp('20210301 00:00:00').tz_localize('CET')
-        df = _make_df_with_one_col(data, period=pd.DateOffset(weeks=1), start_time=start_time)
+        df_end_of_week = _make_df_with_one_col(data, period=pd.DateOffset(weeks=1), start_time=start_time)
         params = ResamplerParams(time_unit="weeks", extrapolation_method='none')
         resampler = Resampler(params)
-        output_df = resampler.transform(df, TIME_COL)
+        output_df = resampler.transform(df_end_of_week, TIME_COL)
         np.testing.assert_array_equal(output_df[TIME_COL].values, pd.DatetimeIndex(['2021-03-06T23:00:00.000000000', '2021-03-13T23:00:00.000000000',
                                                                                     '2021-03-20T23:00:00.000000000', '2021-03-27T23:00:00.000000000',
                                                                                     '2021-04-03T22:00:00.000000000', '2021-04-10T22:00:00.000000000',
                                                                                     '2021-04-17T22:00:00.000000000', '2021-04-24T22:00:00.000000000',
-                                                                                    '2021-05-01T22:00:00.000000000']))
+                                                                                    '2021-05-01T22:00:00.000000000', '2021-05-08T22:00:00.000000000']))
+
+    def test_empty_extrapolation_day(self, academy_orders_df):
+        params = ResamplerParams(time_unit="days", extrapolation_method='none')
+        resampler = Resampler(params)
+        output_df = resampler.transform(academy_orders_df, TIME_COL, groupby_columns=[GROUP_COL])
+        resampled_dates = pd.date_range(pd.Timestamp("2013-03-29"), freq="D", periods=62)
+        black_tshirts_F = output_df[output_df[GROUP_COL] == "Black T-Shirt F"]
+        np.testing.assert_array_equal(black_tshirts_F[TIME_COL], resampled_dates)
+        assert np.all(np.isnan(black_tshirts_F.loc[:52, DATA_COL]))
+        assert not np.any(np.isnan(black_tshirts_F.loc[53:-2, DATA_COL]))
+        assert math.isnan(black_tshirts_F[DATA_COL].values[-1])
+
+    def test_empty_interpolation_day(self, academy_orders_df):
+        params = ResamplerParams(time_unit="days", interpolation_method='none')
+        resampler = Resampler(params)
+        output_df = resampler.transform(academy_orders_df, TIME_COL, groupby_columns=[GROUP_COL])
+        black_tshirts_F = output_df[output_df[GROUP_COL] == "Black T-Shirt F"]
+        assert not np.any(np.isnan(black_tshirts_F.loc[:54, DATA_COL]))
+        assert np.all(np.isnan(black_tshirts_F.loc[55:59, DATA_COL]))
+        assert not np.any(np.isnan(black_tshirts_F.loc[60:, DATA_COL]))


### PR DESCRIPTION
[[ch65867]](https://app.clubhouse.io/dataiku/story/65867/regression-in-v2?vc_group_by=day&ct_workflow=all)
The bug fix made in [ch61615](https://app.clubhouse.io/dataiku/story/61615/the-resampling-recipe-adds-an-empty-row-for-weekly-frequencies-without-extrapolation) was actually irrelevant because with the options "don't extrapolate" or "don't interpolate", the user expects that the recipe will resample the data while keeping the numerical values empty.  The [academy](https://academy.dataiku.com/time-series-preparation-1/609999) explains it this way. However, it's confusing because the user may understand that "don't interpolate" means "don't resample" and in this case, this would mean that the recipe would not add the missing dates are between the first date and the last date present in the data. 

In this PR : 
- I reverted the changes made in ch61615. It was a feature, not a bug
- To prevent future misunderstandings, I changed the labels "don't interpolate" and "don't extrapolate' to "empty"
- I added some unit tests with a sample of the Academy dataset
- I will change the wording and the screenshots on the Academy website to make it consistent with the current recipes