### PR TITLE
Pandas 2 compatible code

### DIFF
--- a/python-lib/dku_timeseries/timeseries_helpers.py
+++ b/python-lib/dku_timeseries/timeseries_helpers.py
@@ -7,6 +7,8 @@ from pandas.tseries.frequencies import to_offset
 from pandas.tseries.offsets import BDay
 from pandas.tseries.offsets import Day
 
+from dataiku.base.utils import package_is_at_least
+
 logger = logging.getLogger(__name__)
 
 # Frequency strings as defined in https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases
@@ -18,14 +20,14 @@ FREQUENCY_STRINGS = {
     'weeks': 'W',
     'days': 'D',
     'business_days': 'B',
-    'hours': 'H',
-    'minutes': 'T',
     'seconds': 'S',
     'milliseconds': 'L',
     'microseconds': 'us',
     'nanoseconds': 'ns'
 }
 
+FREQUENCY_STRINGS['hours'] = 'h' if package_is_at_least(pd, "2") else 'H'
+FREQUENCY_STRINGS['minutes'] = 'min' if package_is_at_least(pd, "1") else 'T'
 ROUND_COMPATIBLE_TIME_UNIT = ['days', 'hours', 'minutes', 'seconds', 'milliseconds', 'microseconds', 'nanoseconds']
 UNIT_ORDER = ['years', 'months', 'semi_annual', 'quarters', 'weeks', 'days', 'business_days', 'hours', 'minutes', 'seconds', 'milliseconds', 'microseconds',
               'nanoseconds']

--- a/python-lib/dku_timeseries/windowing.py
+++ b/python-lib/dku_timeseries/windowing.py
@@ -219,19 +219,19 @@ class WindowAggregator:
             new_df[raw_columns] = df_ref[raw_columns]
         if 'min' in self.params.aggregation_types:
             col_names = ['{}_min'.format(col) for col in raw_columns]
-            new_df[col_names] = roller[raw_columns].apply(min, raw=True)
+            new_df[col_names] = roller[raw_columns].apply(min)
         if 'max' in self.params.aggregation_types:
             col_names = ['{}_max'.format(col) for col in raw_columns]
-            new_df[col_names] = roller[raw_columns].apply(max, raw=True)
+            new_df[col_names] = roller[raw_columns].apply(max)
         if 'q25' in self.params.aggregation_types:
             col_names = ['{}_q25'.format(col) for col in raw_columns]
-            new_df[col_names] = roller[raw_columns].quantile(0.25, raw=True)
+            new_df[col_names] = roller[raw_columns].quantile(0.25)
         if 'median' in self.params.aggregation_types:
             col_names = ['{}_median'.format(col) for col in raw_columns]
-            new_df[col_names] = roller[raw_columns].quantile(0.5, raw=True)
+            new_df[col_names] = roller[raw_columns].quantile(0.5)
         if 'q75' in self.params.aggregation_types:
             col_names = ['{}_q75'.format(col) for col in raw_columns]
-            new_df[col_names] = roller[raw_columns].quantile(0.75, raw=True)
+            new_df[col_names] = roller[raw_columns].quantile(0.75)
         if 'first_order_derivative' in self.params.aggregation_types:
             col_names = ['{}_1st_derivative'.format(col) for col in raw_columns]
             if self.params.window_width < 1:

--- a/python-lib/timeseries_preparation/preparation.py
+++ b/python-lib/timeseries_preparation/preparation.py
@@ -255,8 +255,8 @@ def assert_time_column_valid(dataframe, time_column_name, frequency, start_date=
         error_message += " Please check the Frequency parameter or use the resampling recipe from the time series preparation plugin."
         raise ValueError(error_message)
 
-
-FREQUENCY_LABEL = {"T": "minute", "H": "hour", "D": "day", "B": "business day"}
+# Depending on whether pandas 1 or 2 is in use, minute and hour offset names vary (min and h are pandas 2 names)
+FREQUENCY_LABEL = { "min": "minute", "T": "minute", "h": "HOUR", "H": "hour", "D": "day", "B": "business day"}
 
 WEEKDAYS = [
     "Monday",


### PR DESCRIPTION
In pandas 2, HourOffset.name is now "h" instead of "H", MinuteOffset.name is now "min" instead of "T"

We keep both naming in order to have the plugin be compatible with both pandas 1 and 2

Also remove the "raw" parameter from functions calls in windowing.py since it does nothing and is not compatible with pandas2