### PR TITLE
feat(resampling): support setting custom dates for the start and end of extrapolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 2.1.0 - New feature release - 2024-12
+### Resampling recipe
+- :date: Support selecting custom dates for the start and end of extrapolation
+
 ## Version 2.0.4 - Bugfix release - 2024-02
 - :bug: Plugin resamples on columns when they should be interpreted as categorical columns
 

--- a/custom-recipes/timeseries-preparation-resampling/recipe.json
+++ b/custom-recipes/timeseries-preparation-resampling/recipe.json
@@ -269,6 +269,58 @@
       "defaultValue": "clip"
     },
     {
+      "name": "start_date_mode",
+      "label": "Extrapolation start date",
+      "type": "SELECT",
+      "selectChoices": [
+        {
+          "value": "AUTO",
+          "label": "First available"
+        },
+        {
+          "value": "CUSTOM",
+          "label": "Custom"
+        }
+      ],
+      "mandatory": false,
+      "defaultValue": "AUTO",
+      "visibilityCondition": "model.extrapolation_method == 'clip' || (model.extrapolation_method == 'interpolation' && model.interpolation_method != 'none')"
+    },
+    {
+      "name": "custom_start_date",
+      "label": "Custom start date",
+      "type": "DATE",
+      "mandatory": false,
+      "visibilityCondition": "(model.extrapolation_method == 'clip' || (model.extrapolation_method == 'interpolation' && model.interpolation_method != 'none')) && model.start_date_mode == 'CUSTOM'",
+      "description": "Set a custom date to start extrapolation from."
+    },
+    {
+      "name": "end_date_mode",
+      "label": "Extrapolation end date",
+      "type": "SELECT",
+      "selectChoices": [
+        {
+          "value": "AUTO",
+          "label": "Last available"
+        },
+        {
+          "value": "CUSTOM",
+          "label": "Custom"
+        }
+      ],
+      "mandatory": false,
+      "defaultValue": "AUTO",
+      "visibilityCondition": "model.extrapolation_method == 'clip' || (model.extrapolation_method == 'interpolation' && model.interpolation_method != 'none')"
+    },
+    {
+      "name": "custom_end_date",
+      "label": "Custom end date",
+      "type": "DATE",
+      "mandatory": false,
+      "visibilityCondition": "(model.extrapolation_method == 'clip' || (model.extrapolation_method == 'interpolation' && model.interpolation_method != 'none')) && model.end_date_mode == 'CUSTOM'",
+      "description": "Set a custom date to end extrapolation on."
+    },
+    {
       "name": "category_imputation_method",
       "label": "Impute categorical data",
       "description": "Used to fill in categorical values during interpolation and extrapolation",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "timeseries-preparation",
-    "version": "2.0.4",
+    "version": "2.1.0",
     "meta": {
         "supportLevel": "SUPPORTED",
         "label": "Time Series Preparation",

--- a/python-lib/dku_timeseries/resampling.py
+++ b/python-lib/dku_timeseries/resampling.py
@@ -120,15 +120,6 @@ class Resampler:
     def _can_customize_resampling_dates(self):
         return self.params.extrapolation_method == 'clip' or (self.params.extrapolation_method == 'interpolation' and self.params.interpolation_method != 'none')
 
-    def _get_comparable_date(self, raw_date, reference):
-        clean_date = pd.Timestamp(raw_date)
-        clean_date = clean_date.tz_convert(reference.timetz().tzinfo)
-        # round UTC+12 dates down
-        if clean_date.hour == 12:
-            clean_date = clean_date.floor("D")
-        else:
-            clean_date = clean_date.round("D")
-        return clean_date
 
     def _compute_full_time_index(self, df, datetime_column):
         """
@@ -146,13 +137,11 @@ class Resampler:
         if self._can_customize_resampling_dates():
             custom_start_date = self.params.custom_start_date
             if custom_start_date:
-                custom_start_date = self._get_comparable_date(custom_start_date, start_time)
                 if custom_start_date < start_time:
                     start_time = custom_start_date
 
             custom_end_date = self.params.custom_end_date
             if custom_end_date:
-                custom_end_date = self._get_comparable_date(custom_end_date, end_time)
                 if custom_end_date > end_time:
                     end_time = custom_end_date
 

--- a/python-lib/dku_timeseries/resampling.py
+++ b/python-lib/dku_timeseries/resampling.py
@@ -28,7 +28,9 @@ class ResamplerParams:
                  time_unit_end_of_week="SUN",
                  clip_start=0,
                  clip_end=0,
-                 shift=0):
+                 shift=0,
+                 custom_start_date=None,
+                 custom_end_date=None):
 
         self.interpolation_method = interpolation_method
         self.extrapolation_method = extrapolation_method
@@ -42,6 +44,8 @@ class ResamplerParams:
         self.clip_start = reformat_time_value(float(clip_start), time_unit)
         self.clip_end = reformat_time_value(float(clip_end), time_unit)
         self.shift = reformat_time_value(float(shift), time_unit)
+        self.custom_start_date = custom_start_date
+        self.custom_end_date = custom_end_date
 
     def check(self):
 
@@ -113,6 +117,9 @@ class Resampler:
 
         return df_resampled
 
+    def _can_customize_resampling_dates(self):
+        return self.params.extrapolation_method == 'clip' or (self.params.extrapolation_method == 'interpolation' and self.params.interpolation_method != 'none')
+
     def _compute_full_time_index(self, df, datetime_column):
         """
         From the resampling config, create the full index of the output dataframe.
@@ -125,6 +132,20 @@ class Resampler:
         frequency = self.params.resampling_step
         time_step = self.params.time_step
         time_unit = self.params.time_unit
+
+        if self._can_customize_resampling_dates():
+            custom_start_date = self.params.custom_start_date
+            if custom_start_date:
+                custom_start_date = pd.Timestamp(custom_start_date).tz_convert(start_time.timetz().tzinfo)
+                if custom_start_date < start_time:
+                    start_time = custom_start_date
+
+            custom_end_date = self.params.custom_end_date
+            if custom_end_date:
+                custom_end_date = pd.Timestamp(custom_end_date).tz_convert(end_time.timetz().tzinfo)
+                if custom_end_date > end_time:
+                    end_time = custom_end_date
+
         return generate_date_range(start_time, end_time, clip_start, clip_end, shift, frequency, time_step, time_unit)
 
     def _resample(self, df, datetime_column, columns_to_resample, category_columns, reference_time_index, df_id=''):

--- a/python-lib/recipe_config_loading.py
+++ b/python-lib/recipe_config_loading.py
@@ -28,6 +28,10 @@ def get_resampling_params(recipe_config):
     clip_start = _p('clip_start')
     clip_end = _p('clip_end')
     shift = _p('shift')
+    start_date_mode = _p('start_date_mode', 'AUTO')
+    custom_start_date = _p('custom_start_date') if start_date_mode == 'CUSTOM' else None
+    end_date_mode = _p('end_date_mode', 'AUTO')
+    custom_end_date = _p('custom_end_date') if end_date_mode == 'CUSTOM' else None
 
     params = ResamplerParams(interpolation_method=interpolation_method,
                              extrapolation_method=extrapolation_method,
@@ -39,7 +43,9 @@ def get_resampling_params(recipe_config):
                              time_unit_end_of_week=time_unit_end_of_week,
                              clip_start=clip_start,
                              clip_end=clip_end,
-                             shift=shift)
+                             shift=shift,
+                             custom_start_date=custom_start_date,
+                             custom_end_date=custom_end_date)
     params.check()
     return params
 

--- a/python-lib/recipe_config_loading.py
+++ b/python-lib/recipe_config_loading.py
@@ -1,5 +1,7 @@
 import sys
 
+import pandas as pd
+
 from dku_config.stl_config import STLConfig
 from dku_input_validator.decomposition_input_validator import DecompositionInputValidator
 from dku_timeseries import ExtremaExtractorParams
@@ -17,6 +19,24 @@ def get_resampling_params(recipe_config):
     def _p(param_name, default=None):
         return recipe_config.get(param_name, default)
 
+    def date_from_naive_datetime(datetime_str):
+        if not datetime_str:
+            return None
+
+        # the frontend sends a zulu datetime after offsetting it from midnight on the selected day
+        # eg. selecting 2025-01-31 in a browser set to UTC+4 sends "2025-01-30T20:00:00Z"
+        # while a browser set to UTC-4 sends "2025-01-31T04:00:00Z"
+        date = pd.Timestamp(datetime_str)
+
+        # round UTC+12 dates up (includes NZST), UTC-12 is not used anywhere
+        if date.hour == 12:
+            return date.ceil("D")
+        # round UTC+13 dates up (includes NZDT and the state of Samoa), without timezone info UTC-11 looks the same as UTC+13 but the latter only has very few inhabitants (mainly American Samoa)
+        if date.hour == 11:
+            logger.warning("The input date is either UTC-11 or UTC+13, it will be processed as UTC+13")
+            return date.ceil("D")
+        return date.round("D")
+
     interpolation_method = _p('interpolation_method')
     extrapolation_method = _p('extrapolation_method')
     constant_value = _p('constant_value')
@@ -29,9 +49,9 @@ def get_resampling_params(recipe_config):
     clip_end = _p('clip_end')
     shift = _p('shift')
     start_date_mode = _p('start_date_mode', 'AUTO')
-    custom_start_date = _p('custom_start_date') if start_date_mode == 'CUSTOM' else None
+    custom_start_date = date_from_naive_datetime(_p('custom_start_date')) if start_date_mode == 'CUSTOM' else None
     end_date_mode = _p('end_date_mode', 'AUTO')
-    custom_end_date = _p('custom_end_date') if end_date_mode == 'CUSTOM' else None
+    custom_end_date = date_from_naive_datetime(_p('custom_end_date')) if end_date_mode == 'CUSTOM' else None
 
     params = ResamplerParams(interpolation_method=interpolation_method,
                              extrapolation_method=extrapolation_method,

--- a/tests/python/unit/dku_timeseries/resampling/test_resampling.py
+++ b/tests/python/unit/dku_timeseries/resampling/test_resampling.py
@@ -380,17 +380,17 @@ class TestResampler:
 
     def test_extrapolation_custom_dates(self):
         data = [random.random() for _ in range(3)]
-        start_time = pd.Timestamp('2024-12-01 00:00:00').tz_localize('CET')
+        start_time = pd.Timestamp('2024-12-01T00:00:00Z')
         df = _make_df_with_one_col(data, period=pd.DateOffset(days=1), start_time=start_time)
         params = ResamplerParams(time_unit="days",
                                  extrapolation_method='clip',
-                                 custom_start_date="2024-11-30T23:00:00.000Z",
-                                 custom_end_date="2024-12-05T23:00:00.000Z")
+                                 custom_start_date=pd.Timestamp("2024-11-30T00:00:00Z"),
+                                 custom_end_date=pd.Timestamp("2024-12-05T00:00:00Z"))
         resampler = Resampler(params)
         output_df = resampler.transform(df, TIME_COL)
-        np.testing.assert_array_equal(output_df[TIME_COL].values, pd.DatetimeIndex(['2024-11-30T23:00:00.000000000', '2024-12-01T23:00:00.000000000',
-                                                                                    '2024-12-02T23:00:00.000000000', '2024-12-03T23:00:00.000000000',
-                                                                                    '2024-12-04T23:00:00.000000000', '2024-12-05T23:00:00.000000000']))
+        np.testing.assert_array_equal(output_df[TIME_COL].values, pd.DatetimeIndex(['2024-11-30T00:00:00.000000000', '2024-12-01T00:00:00.000000000',
+                                                                                    '2024-12-02T00:00:00.000000000', '2024-12-03T00:00:00.000000000',
+                                                                                    '2024-12-04T00:00:00.000000000', '2024-12-05T00:00:00.000000000']))
 
     def test_no_extrapolation_long_format(self, long_format_df):
         params = ResamplerParams(time_unit="days", extrapolation_method='no_extrapolation')

--- a/tests/python/unit/dku_timeseries/resampling/test_resampling.py
+++ b/tests/python/unit/dku_timeseries/resampling/test_resampling.py
@@ -378,6 +378,20 @@ class TestResampler:
                                                                                     '2021-04-17T22:00:00.000000000', '2021-04-24T22:00:00.000000000',
                                                                                     '2021-05-01T22:00:00.000000000']))
 
+    def test_extrapolation_custom_dates(self):
+        data = [random.random() for _ in range(3)]
+        start_time = pd.Timestamp('2024-12-01 00:00:00').tz_localize('CET')
+        df = _make_df_with_one_col(data, period=pd.DateOffset(days=1), start_time=start_time)
+        params = ResamplerParams(time_unit="days",
+                                 extrapolation_method='clip',
+                                 custom_start_date="2024-11-30T23:00:00.000Z",
+                                 custom_end_date="2024-12-05T23:00:00.000Z")
+        resampler = Resampler(params)
+        output_df = resampler.transform(df, TIME_COL)
+        np.testing.assert_array_equal(output_df[TIME_COL].values, pd.DatetimeIndex(['2024-11-30T23:00:00.000000000', '2024-12-01T23:00:00.000000000',
+                                                                                    '2024-12-02T23:00:00.000000000', '2024-12-03T23:00:00.000000000',
+                                                                                    '2024-12-04T23:00:00.000000000', '2024-12-05T23:00:00.000000000']))
+
     def test_no_extrapolation_long_format(self, long_format_df):
         params = ResamplerParams(time_unit="days", extrapolation_method='no_extrapolation')
         resampler = Resampler(params)

--- a/tests/python/unit/requirements.txt
+++ b/tests/python/unit/requirements.txt
@@ -1,7 +1,6 @@
-pytest
+pytest<8
 allure-pytest==2.8.29
 pandas==1.0.5; python_version < '3.9'
-pandas==1.1.5; python_version == '3.9'
-pandas==1.3.5; python_version > '3.9'
+pandas==1.3.5; python_version >= '3.9'
 numpy==1.21.6; python_version == '3.7'
 numpy==1.23.5; python_version > '3.7'


### PR DESCRIPTION
Default is still to use the first and last known timestamps:

![Screenshot 2024-12-10 at 14 39 22](https://github.com/user-attachments/assets/a28ff97a-52db-499f-8b95-2befd517c724)

Custom dates can be set for either:

![Screenshot 2024-12-10 at 14 40 17](https://github.com/user-attachments/assets/435e57e3-7086-47ad-8063-6bdbe9f44220)

[dss-plugin-timeseries-preparation-2.1.0.zip](https://github.com/user-attachments/files/18080521/dss-plugin-timeseries-preparation-2.1.0.zip)
