### PR TITLE
Fix conversion to rolling compatible date time for some frequencies

### DIFF
--- a/python-lib/dku_timeseries/timeseries_helpers.py
+++ b/python-lib/dku_timeseries/timeseries_helpers.py
@@ -152,6 +152,8 @@ def format_group_id(group_id, identifiers_number):
 
 
 def convert_to_rolling_compatible_time_unit(time_step, time_unit):
+    if time_unit == 'businessdays' or time_unit.startswith("B"):
+        raise Exception("Data with a 'businessdays' frequency cannot be windowed.")
     if time_unit == 'weeks' or time_unit.startswith("W"):
         return 7 * time_step, 'days'
     elif time_unit == 'months' or time_unit.startswith("M"):

--- a/python-lib/dku_timeseries/timeseries_helpers.py
+++ b/python-lib/dku_timeseries/timeseries_helpers.py
@@ -156,8 +156,7 @@ def convert_to_rolling_compatible_time_unit(time_step, time_unit):
         return 7 * time_step, 'days'
     elif time_unit == 'months' or time_unit.startswith("M"):
         return 30 * time_step, 'days'
-    # The S and E (start and end) units sometimes look like "QE-dec", so we split on "-" to get rid of the useless info
-    elif time_unit == 'quarters' or time_unit.split("-")[0] in ["Q","QE","QS"]:
+    elif time_unit == 'quarters' or time_unit.startswith("Q"):
         return 91 * time_step, 'days'
     # There is no half year frequency, those are inferred as two quarters instead in infer_frequency()
     elif time_unit == 'years' or time_unit.startswith("Y") or time_unit.startswith("A"):

--- a/python-lib/dku_timeseries/timeseries_helpers.py
+++ b/python-lib/dku_timeseries/timeseries_helpers.py
@@ -156,7 +156,11 @@ def convert_to_rolling_compatible_time_unit(time_step, time_unit):
         return 7 * time_step, 'days'
     elif time_unit == 'months' or time_unit.startswith("M"):
         return 30 * time_step, 'days'
-    elif time_unit == 'years' or time_unit.startswith("A"):
+    # The S and E (start and end) units sometimes look like "QE-dec", so we split on "-" to get rid of the useless info
+    elif time_unit == 'quarters' or time_unit.split("-")[0] in ["Q","QE","QS"]:
+        return 91 * time_step, 'days'
+    # There is no half year frequency, those are inferred as two quarters instead in infer_frequency()
+    elif time_unit == 'years' or time_unit.startswith("Y") or time_unit.startswith("A"):
         return 365 * time_step, 'days'
     else:
         return time_step, time_unit


### PR DESCRIPTION
QS and QE were missing, Y in some pandas versions is an alternative to A

Repro project : 
[DKU_TUT_VISUALIZATION_11.zip](https://github.com/user-attachments/files/18363301/DKU_TUT_VISUALIZATION_11.zip)

The repro project uses a python recipe to generate data, here are various date arrays useful for testing cases : 
```
['2022-01-01', '2022-07-01', '2023-01-01', '2023-07-01', '2024-01-01', '2024-07-01', '2025-01-01', '2025-07-01', '2026-01-01']
['2022-12-31', '2023-12-31', '2024-12-31', '2025-12-31', '2026-12-31', '2027-12-31', '2028-12-31', '2029-12-31', '2030-12-31']
['2022-07-31', '2022-08-31', '2022-09-30', '2022-10-31', '2022-11-30', '2022-12-31', '2023-01-31', '2023-02-28', '2023-03-31']
['2022-07-01', '2022-08-01', '2022-09-01', '2022-10-01', '2022-11-01', '2022-12-01', '2023-01-01', '2023-02-01', '2023-03-01']
['2022-01-01', '2022-04-01', '2022-07-01', '2022-10-01', '2023-01-01', '2023-04-01', '2023-07-01', '2023-10-01', '2024-01-01']
['2022-07-31', '2022-10-31', '2023-01-31', '2023-04-30', '2023-07-31', '2023-10-31', '2024-01-31', '2024-04-30', '2024-07-31']
```


