### PR TITLE
Allow integers columns with null values to be resampled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+
+## Version 2.1.1 - Bugfix release - 2025-04
+### Resampling recipe
+- :bug: support integer columns containing null values
+- :bug: support float values in resampling
+
 ## Version 2.1.0 - New feature release - 2024-12
 ### Resampling recipe
 - :date: Support selecting custom dates for the start and end of extrapolation

--- a/custom-recipes/timeseries-preparation-resampling/recipe.py
+++ b/custom-recipes/timeseries-preparation-resampling/recipe.py
@@ -11,16 +11,30 @@ check_python_version()
 # --- Setup
 (input_dataset, output_dataset) = get_input_output()
 recipe_config = get_recipe_config()
-input_dataset_columns = [column["name"] for column in input_dataset.read_schema()]
+
+schema = input_dataset.read_schema()
+
+input_dataset_columns = [column["name"] for column in schema]
 check_time_column_parameter(recipe_config, input_dataset_columns)
 groupby_columns = check_and_get_groupby_columns(recipe_config, input_dataset_columns)
 datetime_column = recipe_config.get('datetime_column')
 params = get_resampling_params(recipe_config)
 
 # --- Run
-df = input_dataset.get_dataframe(infer_with_pandas=False)
+df = input_dataset.get_dataframe(infer_with_pandas=False, use_nullable_integers=True)
+
 resampler = Resampler(params)
 output_df = resampler.transform(df, datetime_column, groupby_columns=groupby_columns)
 
+columns_to_round = [
+    column["name"]
+    for column in schema
+    if column["type"] in ["tinyint", "smallint", "int", "bigint"]
+]
+# int columns must be resampled into int values (note that they can also contain NaN values)
+output_df[columns_to_round] = output_df[columns_to_round].round()
+
+
 # --- Write output
-output_dataset.write_with_schema(output_df)
+output_dataset.write_schema(schema)
+output_dataset.write_dataframe(output_df)

--- a/custom-recipes/timeseries-preparation-resampling/recipe.py
+++ b/custom-recipes/timeseries-preparation-resampling/recipe.py
@@ -31,7 +31,7 @@ else:
     df = input_dataset.get_dataframe(infer_with_pandas=False)
 
 resampler = Resampler(params)
-output_df = resampler.transform(df, datetime_column, groupby_columns=groupby_columns, can_use_nullable_integers=can_use_nullable_integers)
+output_df = resampler.transform(df, datetime_column, groupby_columns=groupby_columns)
 
 # int columns must be resampled into int values
 columns_to_round = [

--- a/custom-recipes/timeseries-preparation-resampling/recipe.py
+++ b/custom-recipes/timeseries-preparation-resampling/recipe.py
@@ -13,9 +13,7 @@ check_python_version()
 # --- Setup
 (input_dataset, output_dataset) = get_input_output()
 recipe_config = get_recipe_config()
-
 schema = input_dataset.read_schema()
-
 input_dataset_columns = [column["name"] for column in schema]
 check_time_column_parameter(recipe_config, input_dataset_columns)
 groupby_columns = check_and_get_groupby_columns(recipe_config, input_dataset_columns)
@@ -30,10 +28,10 @@ can_use_nullable_integers = "use_nullable_integers" in signature.parameters
 if can_use_nullable_integers:
     df = input_dataset.get_dataframe(infer_with_pandas=False, use_nullable_integers=True)
 else:
-    df = input_dataset.get_dataframe()
+    df = input_dataset.get_dataframe(infer_with_pandas=False)
 
 resampler = Resampler(params)
-output_df = resampler.transform(df, datetime_column, groupby_columns=groupby_columns)
+output_df = resampler.transform(df, datetime_column, groupby_columns=groupby_columns, can_use_nullable_integers=can_use_nullable_integers)
 
 if can_use_nullable_integers:
     columns_to_round = [

--- a/custom-recipes/timeseries-preparation-resampling/recipe.py
+++ b/custom-recipes/timeseries-preparation-resampling/recipe.py
@@ -33,14 +33,14 @@ else:
 resampler = Resampler(params)
 output_df = resampler.transform(df, datetime_column, groupby_columns=groupby_columns, can_use_nullable_integers=can_use_nullable_integers)
 
-if can_use_nullable_integers:
-    columns_to_round = [
-        column["name"]
-        for column in schema
-        if column["type"] in ["tinyint", "smallint", "int", "bigint"]
-    ]
-    # int columns must be resampled into int values (note that they can also contain NaN values)
-    output_df[columns_to_round] = output_df[columns_to_round].round()
+
+columns_to_round = [
+    column["name"]
+    for column in schema
+    if column["type"] in ["tinyint", "smallint", "int", "bigint"]
+]
+# int columns must be resampled into int values (note that they can also contain NaN values)
+output_df[columns_to_round] = output_df[columns_to_round].round()
 
 
 # --- Write output

--- a/custom-recipes/timeseries-preparation-resampling/recipe.py
+++ b/custom-recipes/timeseries-preparation-resampling/recipe.py
@@ -26,7 +26,7 @@ signature = inspect.signature(input_dataset.get_dataframe)
 can_use_nullable_integers = "use_nullable_integers" in signature.parameters
 
 if can_use_nullable_integers:
-    df = input_dataset.get_dataframe(infer_with_pandas=False, use_nullable_integers=True)
+    df = input_dataset.get_dataframe(infer_with_pandas=False, use_nullable_integers=True, bool_as_string=True)
 else:
     df = input_dataset.get_dataframe(infer_with_pandas=False)
 

--- a/custom-recipes/timeseries-preparation-resampling/recipe.py
+++ b/custom-recipes/timeseries-preparation-resampling/recipe.py
@@ -26,7 +26,7 @@ signature = inspect.signature(input_dataset.get_dataframe)
 can_use_nullable_integers = "use_nullable_integers" in signature.parameters
 
 if can_use_nullable_integers:
-    df = input_dataset.get_dataframe(infer_with_pandas=False, use_nullable_integers=True, bool_as_string=True)
+    df = input_dataset.get_dataframe(infer_with_pandas=False, use_nullable_integers=True, bool_as_str=True)
 else:
     df = input_dataset.get_dataframe(infer_with_pandas=False)
 

--- a/custom-recipes/timeseries-preparation-resampling/recipe.py
+++ b/custom-recipes/timeseries-preparation-resampling/recipe.py
@@ -20,9 +20,9 @@ groupby_columns = check_and_get_groupby_columns(recipe_config, input_dataset_col
 datetime_column = recipe_config.get('datetime_column')
 params = get_resampling_params(recipe_config)
 
-
+# use_nullable_integers is only available in DSS >= 13.1
+# Prior to this, the plugin does not support integer columns with NaN values
 signature = inspect.signature(input_dataset.get_dataframe)
-
 can_use_nullable_integers = "use_nullable_integers" in signature.parameters
 
 if can_use_nullable_integers:
@@ -33,13 +33,12 @@ else:
 resampler = Resampler(params)
 output_df = resampler.transform(df, datetime_column, groupby_columns=groupby_columns, can_use_nullable_integers=can_use_nullable_integers)
 
-
+# int columns must be resampled into int values
 columns_to_round = [
     column["name"]
     for column in schema
     if column["type"] in ["tinyint", "smallint", "int", "bigint"]
 ]
-# int columns must be resampled into int values (note that they can also contain NaN values)
 output_df[columns_to_round] = output_df[columns_to_round].round()
 
 

--- a/custom-recipes/timeseries-preparation-resampling/recipe.py
+++ b/custom-recipes/timeseries-preparation-resampling/recipe.py
@@ -6,6 +6,8 @@ from dku_timeseries import Resampler
 from io_utils import get_input_output
 from recipe_config_loading import check_and_get_groupby_columns, check_time_column_parameter, check_python_version, get_resampling_params
 
+import inspect
+
 check_python_version()
 
 # --- Setup
@@ -20,19 +22,27 @@ groupby_columns = check_and_get_groupby_columns(recipe_config, input_dataset_col
 datetime_column = recipe_config.get('datetime_column')
 params = get_resampling_params(recipe_config)
 
-# --- Run
-df = input_dataset.get_dataframe(infer_with_pandas=False, use_nullable_integers=True)
+
+signature = inspect.signature(input_dataset.get_dataframe)
+
+can_use_nullable_integers = "use_nullable_integers" in signature.parameters
+
+if can_use_nullable_integers:
+    df = input_dataset.get_dataframe(infer_with_pandas=False, use_nullable_integers=True)
+else:
+    df = input_dataset.get_dataframe()
 
 resampler = Resampler(params)
 output_df = resampler.transform(df, datetime_column, groupby_columns=groupby_columns)
 
-columns_to_round = [
-    column["name"]
-    for column in schema
-    if column["type"] in ["tinyint", "smallint", "int", "bigint"]
-]
-# int columns must be resampled into int values (note that they can also contain NaN values)
-output_df[columns_to_round] = output_df[columns_to_round].round()
+if can_use_nullable_integers:
+    columns_to_round = [
+        column["name"]
+        for column in schema
+        if column["type"] in ["tinyint", "smallint", "int", "bigint"]
+    ]
+    # int columns must be resampled into int values (note that they can also contain NaN values)
+    output_df[columns_to_round] = output_df[columns_to_round].round()
 
 
 # --- Write output

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "timeseries-preparation",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "meta": {
         "supportLevel": "SUPPORTED",
         "label": "Time Series Preparation",

--- a/python-lib/dku_timeseries/resampling.py
+++ b/python-lib/dku_timeseries/resampling.py
@@ -2,6 +2,7 @@
 import logging
 
 import pandas as pd
+import numpy as np
 from scipy import interpolate
 
 from dku_timeseries.dataframe_helpers import has_duplicates, nothing_to_do, filter_empty_columns, generic_check_compute_arguments
@@ -78,6 +79,9 @@ class Resampler:
         self.params.check()
 
     def transform(self, df, datetime_column, groupby_columns=None):
+        numeric_columns = df.select_dtypes(include=['number']).columns
+        df[numeric_columns] = df[numeric_columns].astype('float64')
+        
         if groupby_columns is None:
             groupby_columns = []
 
@@ -94,7 +98,7 @@ class Resampler:
         # when having multiple timeseries, their time range is not necessarily the same
         # we thus compute a unified time index for all partitions
         reference_time_index = self._compute_full_time_index(df_copy, datetime_column)
-        columns_to_resample = [col for col in df_copy.select_dtypes([int, float]).columns.tolist() if col != datetime_column and col not in groupby_columns]
+        columns_to_resample = [col for col in df_copy.select_dtypes([int, float, np.float32, np.int32]).columns.tolist() if col != datetime_column and col not in groupby_columns]
         category_columns = [col for col in df.select_dtypes([object, bool]).columns.tolist() if col != datetime_column and col not in columns_to_resample and
                             col not in groupby_columns]
         if groupby_columns:

--- a/python-lib/dku_timeseries/resampling.py
+++ b/python-lib/dku_timeseries/resampling.py
@@ -78,9 +78,10 @@ class Resampler:
         self.params = params
         self.params.check()
 
-    def transform(self, df, datetime_column, groupby_columns=None):
-        numeric_columns = df.select_dtypes(include=['number']).columns
-        df[numeric_columns] = df[numeric_columns].astype('float64')
+    def transform(self, df, datetime_column, groupby_columns=None, can_use_nullable_integers=False):
+        if can_use_nullable_integers:
+            numeric_columns = df.select_dtypes(include=['number']).columns
+            df[numeric_columns] = df[numeric_columns].astype('float64')
         
         if groupby_columns is None:
             groupby_columns = []


### PR DESCRIPTION
[sc-229823]
[sc-223986]

# What

- support integer columns containing null values
- support float values in resampling

# Why

In version 2.0.4 of the plugin, we stopped relying on the inferred pandas type when reading a column. This was done to prevent 'categorical' columns containing just integers being resampled as integers

Unfortunately, this broke the handling of integer columns containing null values.


# Tests

I have updated the integration tests - a few rounding errors, a few errors following the timestamp changes

# Known issues

Currently, a date with string format `2020-05-27T00:00:00.000000Z` will be outputted as `2020-05-27T00:00:00.000000+0000`

This occurs with a simple python recipe which simply reads the contents of this dataset and outputs it to a new dataset