### PR TITLE
Fix tz conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 2.1.2 - Bugfix release - 2025-05
+### Resampling recipe
+- :bug: fix 3.8/3.11 python support
 
 ## Version 2.1.1 - Bugfix release - 2025-04
 ### Resampling recipe

--- a/custom-recipes/timeseries-preparation-resampling/recipe.py
+++ b/custom-recipes/timeseries-preparation-resampling/recipe.py
@@ -39,7 +39,7 @@ columns_to_round = [
     for column in schema
     if column["type"] in ["tinyint", "smallint", "int", "bigint"]
 ]
-output_df[columns_to_round] = output_df[columns_to_round].round()
+output_df[columns_to_round].astype(float).round().astype(int)
 
 
 # --- Write output

--- a/custom-recipes/timeseries-preparation-resampling/recipe.py
+++ b/custom-recipes/timeseries-preparation-resampling/recipe.py
@@ -34,12 +34,13 @@ resampler = Resampler(params)
 output_df = resampler.transform(df, datetime_column, groupby_columns=groupby_columns)
 
 # int columns must be resampled into int values
-columns_to_round = [
+dss_expected_integer_columns = [
     column["name"]
     for column in schema
     if column["type"] in ["tinyint", "smallint", "int", "bigint"]
 ]
-output_df[columns_to_round].astype(float).round().astype(int)
+columns_to_round = [c for c in df.select_dtypes(include="inexact").columns if c in dss_expected_integer_columns]
+output_df[columns_to_round] = output_df[columns_to_round].round()
 
 
 # --- Write output

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "timeseries-preparation",
-    "version": "2.1.1",
+    "version": "2.1.2",
     "meta": {
         "supportLevel": "SUPPORTED",
         "label": "Time Series Preparation",

--- a/python-lib/dku_timeseries/resampling.py
+++ b/python-lib/dku_timeseries/resampling.py
@@ -240,7 +240,10 @@ class Resampler:
             for col in category_columns:
                 # only perform conversion if the column has a timezone
                 if pd.api.types.is_datetime64_any_dtype(category_filled_df[col]) and category_filled_df[col].dt.tz is not None:
-                    most_frequent_categoricals[col] = most_frequent_categoricals[col].tz_localize("UTC")
+                    if most_frequent_categoricals[col].tzinfo is None: # tz-naive timestamp -> localize
+                        most_frequent_categoricals[col] = most_frequent_categoricals[col].tz_localize("UTC")
+                    else: # tz_convert
+                        most_frequent_categoricals[col] = most_frequent_categoricals[col].tz_convert("UTC")
 
             category_filled_df.loc[:, category_columns] = category_filled_df.loc[:, category_columns].fillna(most_frequent_categoricals)
         return category_filled_df

--- a/tests/python/unit/dku_timeseries/resampling/test_category_methods.py
+++ b/tests/python/unit/dku_timeseries/resampling/test_category_methods.py
@@ -289,7 +289,7 @@ class TestCategoryMethods:
         params = get_resampling_params(config)
         resampler = Resampler(params)
         output_df = resampler.transform(df_multiple_dates, columns.date)
-        assert pd.isnull(output_df.loc[1, "date2"])
+        np.testing.assert_array_equal(pd.to_datetime(output_df['date2']).map(lambda s: s.strftime('%Y-%m-%d')), np.array(["2013-01-01", "2013-01-01", "2013-01-01", "2013-01-01", "2013-01-03", "2013-01-03", "2013-01-04", "2013-01-04", "2013-01-05", "2013-01-05", "2013-01-06"]))
 
     def test_bool_column(self, bool_df, config,columns):
         config["category_imputation_method"] = "previous"


### PR DESCRIPTION
The `mode` return value can differ depending of pandas versions. Prior `1.5.1` it was returning a tz naive timestamp therefore requiring the use of `tz_localize` and after it returned a tz aware timestamp requiring the use of `tz_convert`. This was a bug since `.dt.tz is not None` check was checking the tz of the column but not the mode timestamp.